### PR TITLE
fix: Always Send `Content-Type: application/json`

### DIFF
--- a/src/http/iot/http.cpp
+++ b/src/http/iot/http.cpp
@@ -84,7 +84,7 @@ class PlatformHTTP : public AbstractHTTP
             http.setTimeout(3000);
             http.begin(this->host_, this->port_, request);
 
-            http.addHeader("Content-Type", "application/x-www-form-urlencoded");
+            http.addHeader("Content-Type", "application/json");
             http.POST(body);
             return http.getString().c_str();
         }

--- a/src/http/os/http.cpp
+++ b/src/http/os/http.cpp
@@ -73,7 +73,14 @@ class PlatformHTTP : public AbstractHTTP
             curl = curl_easy_init();
             if(curl) {
                 curl_easy_setopt(curl, CURLOPT_URL, ss.str().c_str()); // Set the URL that is about to receive our POST
-                curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body); // Now specify the POST data ex: "username=baldninja"
+
+                /* make header with content-type */
+                struct curl_slist *header = NULL;
+                curl_slist_append(header, "Content-Type: application/json");
+
+                /* set header & body */
+                curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header); // Set Header
+                curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body); // Now specify the POST json data ex: "username=baldninja"
                 
                 /* skip https verification */
                 curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L); // Do NOT verify peer


### PR DESCRIPTION

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Per "Always send `Content-Type: application/json`" #20 

Set header `content-type` for IoT and OS builds.


IoT: 
>` http/iot/http.cpp`
```diff
- http.addHeader("Content-Type", "application/x-www-form-urlencoded");
+ http.addHeader("Content-Type", "application/json");
```

OS:
> `http/os/http.cpp`
```diff
+ struct curl_slist *header = NULL;
+ curl_slist_append(header, "Content-Type: application/json");
+ curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Test fail due to missing ms in timestamp strings, #22 resolves this.
