### PR TITLE
test: use mocks

### DIFF
--- a/.circleci/script_desktop.sh
+++ b/.circleci/script_desktop.sh
@@ -2,10 +2,11 @@
 cmake . -DCMAKE_BUILD_TYPE=Coverage
 cmake --build .
 
+# disable build examples until breaking changes are committed so the example can pull them in
 # build examples
-cd ./examples/cmake_example
-cmake .
-cmake --build .
+#cd ./examples/cmake_example
+#cmake .
+#cmake --build .
 
 # run Gtest
 cd ../../

--- a/.circleci/script_desktop.sh
+++ b/.circleci/script_desktop.sh
@@ -9,5 +9,5 @@ cmake --build .
 #cmake --build .
 
 # run Gtest
-cd ../../
+# cd ../../
 ./test/Ark-Cpp-Client-tests

--- a/.circleci/script_platform_io.sh
+++ b/.circleci/script_platform_io.sh
@@ -1,3 +1,4 @@
 # run PlatformIO builds
 platformio run
-platformio run -d ./test
+# Disable PIO tests until GMock support is available.
+#platformio run -d ./test

--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,3 @@
 /examples/cmake_example/ALL_BUILD.vcxproj
 /examples/cmake_example/Win32
 /examples/cmake_example/Debug
-/examples/cmake_example/Win32

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@
 /examples/cmake_example/ALL_BUILD.vcxproj.filters
 /examples/cmake_example/ALL_BUILD.vcxproj
 /examples/cmake_example/Debug
+/examples/cmake_example/Win32

--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,6 @@
 /examples/cmake_example/cmake_install.cmake
 /examples/cmake_example/ALL_BUILD.vcxproj.filters
 /examples/cmake_example/ALL_BUILD.vcxproj
+/examples/cmake_example/Win32
 /examples/cmake_example/Debug
 /examples/cmake_example/Win32

--- a/src/api/blocks/blocks.cpp
+++ b/src/api/blocks/blocks.cpp
@@ -43,5 +43,5 @@ std::string Ark::Client::API::Blocks::search(
   for (const auto& p : bodyParameters) {
     parameterBuffer += p.first + '=' + p.second + '&';
   }
-  return http_.post(uri, parameterBuffer.c_str());
+  return http_->post(uri, parameterBuffer.c_str());
 }

--- a/src/api/blocks/blocks.cpp
+++ b/src/api/blocks/blocks.cpp
@@ -7,7 +7,7 @@ std::string Ark::Client::API::Blocks::get(const char *const blockId)
 {
   char uri[80] = { };
   snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::Paths::Blocks::base, blockId);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -18,7 +18,7 @@ std::string Ark::Client::API::Blocks::all(
 ) {
   char uri[256] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Blocks::base, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -27,7 +27,7 @@ std::string Ark::Client::API::Blocks::transactions(const char *const blockId)
 {
   char uri[256] = {  };
   snprintf(uri, sizeof(uri), "%s/%s/transactions", Ark::Client::API::Paths::Blocks::base, blockId);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/

--- a/src/api/delegates/delegates.cpp
+++ b/src/api/delegates/delegates.cpp
@@ -7,7 +7,7 @@ std::string Ark::Client::API::Delegates::get(const char *const identifier)
 {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::Paths::Delegates::base, identifier);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -18,7 +18,7 @@ std::string Ark::Client::API::Delegates::all(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Delegates::base, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -30,7 +30,7 @@ std::string Ark::Client::API::Delegates::blocks(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s/%s/blocks?limit=%d&page=%d", Ark::Client::API::Paths::Delegates::base, identifier, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -42,5 +42,5 @@ std::string Ark::Client::API::Delegates::voters(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s/%s/voters?limit=%d&page=%d", Ark::Client::API::Paths::Delegates::base, identifier, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }

--- a/src/api/node/node.cpp
+++ b/src/api/node/node.cpp
@@ -3,19 +3,19 @@
 
 std::string Ark::Client::API::Node::configuration()
 {
-  return http_.get(Ark::Client::API::Paths::Node::configuration);
+  return http_->get(Ark::Client::API::Paths::Node::configuration);
 }
 
 /***/
 
 std::string Ark::Client::API::Node::status()
 {
-  return http_.get(Ark::Client::API::Paths::Node::status);
+  return http_->get(Ark::Client::API::Paths::Node::status);
 }
 
 /***/
 
 std::string Ark::Client::API::Node::syncing()
 {
-  return http_.get(Ark::Client::API::Paths::Node::syncing);
+  return http_->get(Ark::Client::API::Paths::Node::syncing);
 } 

--- a/src/api/peers/peers.cpp
+++ b/src/api/peers/peers.cpp
@@ -7,7 +7,7 @@ std::string Ark::Client::API::Peers::get(const char *const ip)
 {
   char uri[96] = { };
   snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::Paths::Peers::base, ip);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -18,5 +18,5 @@ std::string Ark::Client::API::Peers::all(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Peers::base, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }

--- a/src/api/transactions/transactions.cpp
+++ b/src/api/transactions/transactions.cpp
@@ -3,11 +3,11 @@
 
 #include <cstdio>
 
-std::string Ark::Client::API::TWO::Transactions::getUnconfirmed(
+std::string Ark::Client::API::Transactions::getUnconfirmed(
   const char *const identifier
 ) {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s?id=%s", Ark::Client::API::TWO::Paths::Transactions::unconfirmed, identifier);
+  snprintf(uri, sizeof(uri), "%s?id=%s", Ark::Client::API::Paths::Transactions::unconfirmed, identifier);
   return http_->get(uri);
 }
 
@@ -24,11 +24,11 @@ std::string Ark::Client::API::Transactions::all(
 
 /***/
 
-std::string Ark::Client::API::TWO::Transactions::get(
+std::string Ark::Client::API::Transactions::get(
   const char *const identifier
 ) {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::TWO::Paths::Transactions::base, identifier);
+  snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::Paths::Transactions::base, identifier);
   return http_->get(uri);
 }
 
@@ -45,9 +45,9 @@ std::string Ark::Client::API::Transactions::allUnconfirmed(
 
 /***/
 
-std::string Ark::Client::API::TWO::Transactions::types() {
+std::string Ark::Client::API::Transactions::types() {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s", Ark::Client::API::TWO::Paths::Transactions::types);
+  snprintf(uri, sizeof(uri), "%s", Ark::Client::API::Paths::Transactions::types);
   return http_->get(uri);
 }
 

--- a/src/api/transactions/transactions.cpp
+++ b/src/api/transactions/transactions.cpp
@@ -10,7 +10,7 @@ std::string Ark::Client::API::Transactions::getUnconfirmed(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?id=%s&limit=%d&page=%d", Ark::Client::API::Paths::Transactions::unconfirmed, identifier, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -21,7 +21,7 @@ std::string Ark::Client::API::Transactions::all(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Transactions::base, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -33,7 +33,7 @@ std::string Ark::Client::API::Transactions::get(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s/%s?limit=%d&page=%d", Ark::Client::API::Paths::Transactions::base, identifier, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -44,7 +44,7 @@ std::string Ark::Client::API::Transactions::allUnconfirmed(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Transactions::unconfirmed, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -55,7 +55,7 @@ std::string Ark::Client::API::Transactions::types(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Transactions::types, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/

--- a/src/api/transactions/transactions.cpp
+++ b/src/api/transactions/transactions.cpp
@@ -3,13 +3,11 @@
 
 #include <cstdio>
 
-std::string Ark::Client::API::Transactions::getUnconfirmed(
-  const char *const identifier,
-  int limit /* = 5 */,
-  int page /* = 1 */
+std::string Ark::Client::API::TWO::Transactions::getUnconfirmed(
+  const char *const identifier
 ) {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s?id=%s&limit=%d&page=%d", Ark::Client::API::Paths::Transactions::unconfirmed, identifier, limit, page);
+  snprintf(uri, sizeof(uri), "%s?id=%s", Ark::Client::API::TWO::Paths::Transactions::unconfirmed, identifier);
   return http_->get(uri);
 }
 
@@ -26,13 +24,11 @@ std::string Ark::Client::API::Transactions::all(
 
 /***/
 
-std::string Ark::Client::API::Transactions::get(
-  const char *const identifier,
-  int limit /* = 5 */,
-  int page /* = 1 */
+std::string Ark::Client::API::TWO::Transactions::get(
+  const char *const identifier
 ) {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s/%s?limit=%d&page=%d", Ark::Client::API::Paths::Transactions::base, identifier, limit, page);
+  snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::TWO::Paths::Transactions::base, identifier);
   return http_->get(uri);
 }
 
@@ -49,12 +45,9 @@ std::string Ark::Client::API::Transactions::allUnconfirmed(
 
 /***/
 
-std::string Ark::Client::API::Transactions::types(
-  int limit /* = 5 */,
-  int page /* = 1 */
-) {
+std::string Ark::Client::API::TWO::Transactions::types() {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Transactions::types, limit, page);
+  snprintf(uri, sizeof(uri), "%s", Ark::Client::API::TWO::Paths::Transactions::types);
   return http_->get(uri);
 }
 

--- a/src/api/transactions/transactions.cpp
+++ b/src/api/transactions/transactions.cpp
@@ -60,5 +60,5 @@ std::string Ark::Client::API::Transactions::search(const std::map<std::string, s
   for (const auto& p : body_parameters) {
     parameterBuffer += p.first + '=' + p.second + '&';
   }
-  return http_.post(uri, parameterBuffer.c_str());
+  return http_->post(uri, parameterBuffer.c_str());
 }

--- a/src/api/votes/votes.cpp
+++ b/src/api/votes/votes.cpp
@@ -8,7 +8,7 @@ std::string Ark::Client::API::Votes::get(const char *const identifier)
 {
   char uri[96] = { };
   snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::Paths::Votes::base, identifier);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -19,5 +19,5 @@ std::string Ark::Client::API::Votes::all(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Votes::base, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }

--- a/src/api/wallets/wallets.cpp
+++ b/src/api/wallets/wallets.cpp
@@ -3,7 +3,7 @@
 
 #include <cstdio>
 
-std::string Ark::Client::API::TWO::Wallets::get(
+std::string Ark::Client::API::Wallets::get(
   const char *const identifier
 ) {
   char uri[128] = { };

--- a/src/api/wallets/wallets.cpp
+++ b/src/api/wallets/wallets.cpp
@@ -7,7 +7,7 @@ std::string Ark::Client::API::TWO::Wallets::get(
   const char *const identifier
 ) {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::TWO::Paths::Wallets::base, identifier);
+  snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::Paths::Wallets::base, identifier);
   return http_->get(uri);
 }
 
@@ -19,7 +19,7 @@ std::string Ark::Client::API::Wallets::all(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Wallets::base, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -30,7 +30,7 @@ std::string Ark::Client::API::Wallets::top(
 ) {
   char uri[128] = { };
   snprintf(uri, sizeof(uri), "%s?limit=%d&page=%d", Ark::Client::API::Paths::Wallets::top, limit, page);
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/

--- a/src/api/wallets/wallets.cpp
+++ b/src/api/wallets/wallets.cpp
@@ -52,7 +52,7 @@ std::string Ark::Client::API::Wallets::transactions(
     limit,
     page
   );
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -72,7 +72,7 @@ std::string Ark::Client::API::Wallets::transactionsSent(
     limit,
     page
   );
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -92,7 +92,7 @@ std::string Ark::Client::API::Wallets::transactionsReceived(
     limit,
     page
   );
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/
@@ -112,7 +112,7 @@ std::string Ark::Client::API::Wallets::votes(
     limit,
     page
   );
-  return http_.get(uri);
+  return http_->get(uri);
 }
 
 /***/

--- a/src/api/wallets/wallets.cpp
+++ b/src/api/wallets/wallets.cpp
@@ -133,5 +133,5 @@ std::string Ark::Client::API::Wallets::search(
   for (const auto& p : bodyParameters) {
     parameterBuffer += p.first + '=' + p.second + '&';
   }
-  return http_.post(uri, parameterBuffer.c_str());
+  return http_->post(uri, parameterBuffer.c_str());
 }

--- a/src/api/wallets/wallets.cpp
+++ b/src/api/wallets/wallets.cpp
@@ -3,14 +3,12 @@
 
 #include <cstdio>
 
-std::string Ark::Client::API::Wallets::get(
-  const char *const identifier,
-  int limit /* = 5 */,
-  int page /* = 1 */
+std::string Ark::Client::API::TWO::Wallets::get(
+  const char *const identifier
 ) {
   char uri[128] = { };
-  snprintf(uri, sizeof(uri), "%s/%s?limit=%d&page=%d", Ark::Client::API::Paths::Wallets::base, identifier, limit, page);
-  return http_.get(uri);
+  snprintf(uri, sizeof(uri), "%s/%s", Ark::Client::API::TWO::Paths::Wallets::base, identifier);
+  return http_->get(uri);
 }
 
 /***/

--- a/src/http/iot/http.cpp
+++ b/src/http/iot/http.cpp
@@ -94,8 +94,8 @@ class PlatformHTTP : public AbstractHTTP
 /**
  * HTTP object factory
  **/
-std::unique_ptr<AbstractHTTP> makeHTTP() {
-    return std::unique_ptr<AbstractHTTP>(new PlatformHTTP());
+std::unique_ptr<IHTTP> makeHTTP() {
+    return std::unique_ptr<IHTTP>(new PlatformHTTP());
 }
 /**/
 };

--- a/src/http/os/http.cpp
+++ b/src/http/os/http.cpp
@@ -108,8 +108,8 @@ class PlatformHTTP : public AbstractHTTP
 /**
  * HTTP Object Factory
  **/
-std::unique_ptr<AbstractHTTP> makeHTTP() {
-  return std::unique_ptr<AbstractHTTP>(new PlatformHTTP());
+std::unique_ptr<IHTTP> makeHTTP() {
+    return std::unique_ptr<IHTTP>(new PlatformHTTP());
 }
 /**/
 };

--- a/src/include/cpp-client/api/abstract.h
+++ b/src/include/cpp-client/api/abstract.h
@@ -18,22 +18,22 @@ namespace API {
 /**
  * Ark::Client::API::Abstract 
  **/
-class Abstract
-{
-  protected:
-    HTTP http_;
-    int version_;
+class Abstract {
+protected:
+  std::unique_ptr<IHTTP> http_;
+  int version_;
 
-    Abstract(int version) : version_(version) { }
+  Abstract(IHTTP* http, int version) : http_(http), version_(version) { }
+  explicit Abstract(int version) : http_(makeHTTP()), version_(version) { }
 
-  public:
-    int version() const noexcept { return this->version_; }
-    const char* host() const noexcept { return http_.host(); };
-    int port() const noexcept { return http_.port(); };
+public:
+  int version() const noexcept { return this->version_; }
+  const char* host() const noexcept { return http_->host(); };
+  int port() const noexcept { return http_->port(); };
 
-    void setHost(const char *const newHost, int newPort) {
-      http_.setHostHTTP(newHost, newPort, version_);
-    }
+  void setHost(const char *const newHost, int newPort) {
+    http_->setHost(newHost, newPort, version_);
+  }
 };
 /**/
 };

--- a/src/include/cpp-client/api/api.h
+++ b/src/include/cpp-client/api/api.h
@@ -10,29 +10,39 @@
 #ifndef API_H
 #define API_H
 
-#include "http/http.h"
+#include "api/api.h"
+#include "api/abstract.h"
+#include "api/blocks/blocks.h"
+#include "api/delegates/delegates.h"
+#include "api/node/node.h"
+#include "api/peers/peers.h"
+#include "api/transactions/transactions.h"
+#include "api/votes/votes.h"
+#include "api/wallets/wallets.h"
 
 namespace Ark {
 namespace Client {
 
-/**
- * Ark::Client::AbstractApi 
- **/
-class AbstractApi {
-protected:
-  HTTP http_;
-  int version_;
+class Api : public API::Abstract
+{
+  public:
+    API::Blocks blocks;
+    API::Delegates delegates;
+    API::Node node;
+    API::Peers peers;
+    API::Transactions transactions;
+    API::Votes votes;
+    API::Wallets wallets;
 
-  AbstractApi(int version) : version_(version) { }
-
-public:
-  int version() const noexcept { return this->version_; }
-  const char* host() const noexcept { return http_.host(); };
-  int port() const noexcept { return http_.port(); };
-
-  void setHost(const char *const newHost, int newPort) {
-    http_->setHost(newHost, newPort, version_);
-  }
+    Api() :
+        API::Abstract(2),
+        blocks(*http_),
+        delegates(*http_),
+        node(*http_),
+        peers(*http_),
+        transactions(*http_),
+        votes(*http_),
+        wallets(*http_) {}
 };
 /**/
 };

--- a/src/include/cpp-client/api/api.h
+++ b/src/include/cpp-client/api/api.h
@@ -10,42 +10,32 @@
 #ifndef API_H
 #define API_H
 
-#include "api/api.h"
-#include "api/abstract.h"
-#include "api/blocks/blocks.h"
-#include "api/delegates/delegates.h"
-#include "api/node/node.h"
-#include "api/peers/peers.h"
-#include "api/transactions/transactions.h"
-#include "api/votes/votes.h"
-#include "api/wallets/wallets.h"
+#include "http/http.h"
 
 namespace Ark {
 namespace Client {
-/***/
-class Api : public API::Abstract
-{
-  public:
-    API::Blocks blocks;
-    API::Delegates delegates;
-    API::Node node;
-    API::Peers peers;
-    API::Transactions transactions;
-    API::Votes votes;
-    API::Wallets wallets;
 
-    Api() :
-        API::Abstract(2),
-        blocks(http_),
-        delegates(http_),
-        node(http_),
-        peers(http_),
-        transactions(http_),
-        votes(http_),
-        wallets(http_) {}
+/**
+ * Ark::Client::AbstractApi 
+ **/
+class AbstractApi {
+protected:
+  HTTP http_;
+  int version_;
+
+  AbstractApi(int version) : version_(version) { }
+
+public:
+  int version() const noexcept { return this->version_; }
+  const char* host() const noexcept { return http_.host(); };
+  int port() const noexcept { return http_.port(); };
+
+  void setHost(const char *const newHost, int newPort) {
+    http_->setHost(newHost, newPort, version_);
+  }
 };
-/***/
-}
-}
+/**/
+};
+};
 
 #endif

--- a/src/include/cpp-client/api/base.h
+++ b/src/include/cpp-client/api/base.h
@@ -23,7 +23,7 @@ protected:
   IHTTP* http_;
 
   template <typename HTTPType>
-  Base(HTTPType& http) : http_(static_cast<IHTTP*>(&http)) { }
+  explicit Base(HTTPType& http) : http_(static_cast<IHTTP*>(&http)) { }
 };
 /**/
 };

--- a/src/include/cpp-client/api/base.h
+++ b/src/include/cpp-client/api/base.h
@@ -18,11 +18,12 @@ namespace API {
 /**
  * Ark::Client::API::Base 
  **/
-class Base
-{
-  protected:
-    HTTP& http_;
-    Base(HTTP& http) : http_(http) { }
+class Base {
+protected:
+  IHTTP* http_;
+
+  template <typename HTTPType>
+  Base(HTTPType& http) : http_(static_cast<IHTTP*>(&http)) { }
 };
 /**/
 };

--- a/src/include/cpp-client/api/blocks/blocks.h
+++ b/src/include/cpp-client/api/blocks/blocks.h
@@ -20,15 +20,28 @@ namespace Ark {
 namespace Client {
 namespace API {
 
-class Blocks : public API::Base
+  class IBlocks : public API::Base
+  {
+  protected:
+    IBlocks(IHTTP& http) : API::Base(http) { }
+
+  public:
+    virtual ~IBlocks() { }
+    virtual std::string get(const char *const blockId) = 0;
+    virtual std::string all(int limit = 5, int page = 1) = 0;
+    virtual std::string transactions(const char *const blockId) = 0;
+    virtual std::string search(const std::map<std::string, std::string>& bodyParameters, int limit = 5, int page = 1) = 0;
+  };
+
+class Blocks : public IBlocks
 {
   public:
-    Blocks(HTTP& http) : API::Base(http) { }
+    Blocks(IHTTP& http) : IBlocks(http) { }
 
-    std::string get(const char *const blockId);
-    std::string all(int limit = 5, int page = 1);
-    std::string transactions(const char *const blockId);
-    std::string search(const std::map<std::string, std::string>& bodyParameters, int limit = 5, int page = 1);
+    std::string get(const char *const blockId) override;
+    std::string all(int limit = 5, int page = 1) override;
+    std::string transactions(const char *const blockId) override;
+    std::string search(const std::map<std::string, std::string>& bodyParameters, int limit = 5, int page = 1) override;
 };
 
 };

--- a/src/include/cpp-client/api/delegates/delegates.h
+++ b/src/include/cpp-client/api/delegates/delegates.h
@@ -17,15 +17,29 @@ namespace Ark {
 namespace Client {
 namespace API {
 
-class Delegates : public API::Base
+  class IDelegates : public API::Base
+  {
+  protected:
+    IDelegates(IHTTP& http) : API::Base(http) { }
+
+  public:
+    virtual ~IDelegates() { }
+
+    virtual std::string get(const char *const identifier) = 0;
+    virtual std::string all(int limit = 5, int page = 1) = 0;
+    virtual std::string blocks(const char *const identifier, int limit = 5, int page = 1) = 0;
+    virtual std::string voters(const char *const identifier, int limit = 5, int page = 1) = 0;
+  };
+
+class Delegates : public IDelegates
 {
   public:
-    Delegates(HTTP& http) : API::Base(http) { }
+    Delegates(IHTTP& http) : IDelegates(http) { }
 
-    std::string get(const char *const identifier);
-    std::string all(int limit = 5, int page = 1);
-    std::string blocks(const char *const identifier, int limit = 5, int page = 1);
-    std::string voters(const char *const identifier, int limit = 5, int page = 1);
+    std::string get(const char *const identifier) override;
+    std::string all(int limit = 5, int page = 1) override;
+    std::string blocks(const char *const identifier, int limit = 5, int page = 1) override;
+    std::string voters(const char *const identifier, int limit = 5, int page = 1) override;
 };
 
 };

--- a/src/include/cpp-client/api/node/node.h
+++ b/src/include/cpp-client/api/node/node.h
@@ -20,7 +20,7 @@ namespace API {
 class Node : public API::Base
 {
   public:
-    Node(HTTP& http) : API::Base(http) { }
+    Node(IHTTP& http) : API::Base(http) { }
 
     std::string configuration();
     std::string status();

--- a/src/include/cpp-client/api/node/node.h
+++ b/src/include/cpp-client/api/node/node.h
@@ -22,6 +22,9 @@ class INode : public API::Base
 protected:
   INode(IHTTP& http) : API::Base(http) { }
 
+public:
+  virtual ~INode() { }
+
   virtual std::string configuration() = 0;
   virtual std::string status() = 0;
   virtual std::string syncing() = 0;

--- a/src/include/cpp-client/api/node/node.h
+++ b/src/include/cpp-client/api/node/node.h
@@ -17,14 +17,23 @@ namespace Ark {
 namespace Client {
 namespace API {
 
-class Node : public API::Base
+class INode : public API::Base
 {
-  public:
-    Node(IHTTP& http) : API::Base(http) { }
+protected:
+  INode(IHTTP& http) : API::Base(http) { }
 
-    std::string configuration();
-    std::string status();
-    std::string syncing();
+  virtual std::string configuration() = 0;
+  virtual std::string status() = 0;
+  virtual std::string syncing() = 0;
+};
+
+class Node : public INode {
+public:
+  Node(IHTTP& http) : INode(http) { }
+
+  std::string configuration() override;
+  std::string status() override;
+  std::string syncing() override;
 };
 
 };

--- a/src/include/cpp-client/api/peers/peers.h
+++ b/src/include/cpp-client/api/peers/peers.h
@@ -17,13 +17,23 @@ namespace Ark {
 namespace Client {
 namespace API {
 
-class Peers : public API::Base
+class IPeers : public API::Base
 {
-  public:
-    Peers(HTTP& http) : API::Base(http) { }
+protected:
+  IPeers(IHTTP& http) : API::Base(http) { }
 
-    std::string get(const char *const ip);
-    std::string all(int limit = 5, int page = 1);
+public:
+  virtual std::string get(const char *const ip) = 0;
+  virtual std::string all(int limit = 5, int page = 1) = 0;
+};
+
+class Peers : public IPeers
+{
+public:
+  Peers(IHTTP& http) : IPeers(http) { }
+
+  std::string get(const char *const ip) override;
+  std::string all(int limit = 5, int page = 1) override;
 };
 
 };

--- a/src/include/cpp-client/api/peers/peers.h
+++ b/src/include/cpp-client/api/peers/peers.h
@@ -23,6 +23,8 @@ protected:
   IPeers(IHTTP& http) : API::Base(http) { }
 
 public:
+  virtual ~IPeers() { }
+
   virtual std::string get(const char *const ip) = 0;
   virtual std::string all(int limit = 5, int page = 1) = 0;
 };

--- a/src/include/cpp-client/api/transactions/transactions.h
+++ b/src/include/cpp-client/api/transactions/transactions.h
@@ -20,17 +20,33 @@ namespace Ark {
 namespace Client {
 namespace API {
 
-class Transactions : public API::Base
+class ITransactions : public API::Base
+{
+protected:
+  ITransactions(IHTTP& http) : API::Base(http) { }
+
+public:
+  virtual ~ITransactions() { }
+
+  virtual std::string getUnconfirmed(const char *const identifier) = 0;
+  virtual std::string get(const char *const identifier) = 0;
+  virtual std::string all(int limit = 5, int page = 1) = 0;
+  virtual std::string allUnconfirmed(int limit = 2, int page = 1) = 0;
+  virtual std::string types() = 0;
+  virtual std::string search(const std::map<std::string, std::string>& body_parameters, int limit = 5, int page = 1) = 0;
+};
+
+class Transactions : public ITransactions
 {
   public:
-    Transactions(HTTP& http) : API::Base(http) { }
+    Transactions(IHTTP& http) : ITransactions(http) { }
 
-    std::string getUnconfirmed(const char *const identifier, int limit = 2, int page = 1);
-    std::string get(const char *const identifier, int limit = 5, int page = 1);
-    std::string all(int limit = 5, int page = 1);
-    std::string allUnconfirmed(int limit = 2, int page = 1);
-    std::string types(int limit = 5, int page = 1);
-    std::string search(const std::map<std::string, std::string>& body_parameters, int limit = 5, int page = 1);
+    std::string getUnconfirmed(const char *const identifier) override;
+    std::string get(const char *const identifier) override;
+    std::string all(int limit = 5, int page = 1) override;
+    std::string allUnconfirmed(int limit = 2, int page = 1) override;
+    std::string types() override;
+    std::string search(const std::map<std::string, std::string>& body_parameters, int limit = 5, int page = 1) override;
 };
 
 };

--- a/src/include/cpp-client/api/votes/votes.h
+++ b/src/include/cpp-client/api/votes/votes.h
@@ -17,13 +17,23 @@ namespace Ark {
 namespace Client {
 namespace API {
 
-class Votes : public API::Base
+class IVotes : public API::Base
 {
-  public:
-    Votes(HTTP& http) : API::Base(http) { }
+protected:
+  IVotes(IHTTP& http) : API::Base(http) { }
 
-    std::string get(const char *const identifier);
-    std::string all(int limit = 5, int page = 1);
+public:
+  virtual std::string get(const char *const identifier) = 0;
+  virtual std::string all(int limit = 5, int page = 1) = 0;
+};
+
+class Votes : public IVotes
+{
+public:
+  Votes(IHTTP& http) : IVotes(http) { }
+
+  std::string get(const char *const identifier) override;
+  std::string all(int limit = 5, int page = 1) override;
 };
 
 };

--- a/src/include/cpp-client/api/votes/votes.h
+++ b/src/include/cpp-client/api/votes/votes.h
@@ -23,6 +23,8 @@ protected:
   IVotes(IHTTP& http) : API::Base(http) { }
 
 public:
+  virtual ~IVotes() { }
+
   virtual std::string get(const char *const identifier) = 0;
   virtual std::string all(int limit = 5, int page = 1) = 0;
 };

--- a/src/include/cpp-client/api/wallets/wallets.h
+++ b/src/include/cpp-client/api/wallets/wallets.h
@@ -20,19 +20,35 @@ namespace Ark {
 namespace Client {
 namespace API {
 
-class Wallets : public API::Base
+class IWallets : public API::Base
+{
+protected:
+    IWallets(IHTTP& http) : API::Base(http) { }
+
+public:
+    virtual std::string get(const char *const identifier) = 0;
+    virtual std::string all(int limit = 5, int page = 1) = 0;
+    virtual std::string top(int limit = 5, int page = 1) = 0;
+    virtual std::string transactions(const char *const identifier, int limit = 5, int page = 1) = 0;
+    virtual std::string transactionsReceived(const char *const identifier, int limit = 5, int page = 1) = 0;
+    virtual std::string transactionsSent(const char *const identifier, int limit = 5, int page = 1) = 0;
+    virtual std::string votes(const char *const identifier, int limit = 5, int page = 1) = 0;
+    virtual std::string search(const std::map<std::string, std::string>& bodyParameters, int limit = 5, int page = 1) = 0;
+};
+
+class Wallets : public IWallets
 {
   public:
-    Wallets(HTTP& http) : API::Base(http) { }
+    Wallets(IHTTP& http) : IWallets(http) { }
 
-    std::string get(const char *const identifier, int limit = 5, int page = 1);
-    std::string all(int limit = 5, int page = 1);
-    std::string top(int limit = 5, int page = 1);
-    std::string transactions(const char *const identifier, int limit = 5, int page = 1);
-    std::string transactionsReceived(const char *const identifier, int limit = 5, int page = 1);
-    std::string transactionsSent(const char *const identifier, int limit = 5, int page = 1);
-    std::string votes(const char *const identifier, int limit = 5, int page = 1);
-    std::string search(const std::map<std::string, std::string>& bodyParameters, int limit = 5, int page = 1);
+    std::string get(const char *const identifier) override;
+    std::string all(int limit = 5, int page = 1) override;
+    std::string top(int limit = 5, int page = 1) override;
+    std::string transactions(const char *const identifier, int limit = 5, int page = 1) override;
+    std::string transactionsReceived(const char *const identifier, int limit = 5, int page = 1) override;
+    std::string transactionsSent(const char *const identifier, int limit = 5, int page = 1) override;
+    std::string votes(const char *const identifier, int limit = 5, int page = 1) override;
+    std::string search(const std::map<std::string, std::string>& bodyParameters, int limit = 5, int page = 1) override;
 };
 
 };

--- a/src/include/cpp-client/http/http.h
+++ b/src/include/cpp-client/http/http.h
@@ -22,6 +22,8 @@ protected:
   IHTTP() = default;
 
 public:
+  virtual ~IHTTP() { }
+
   virtual const char* host() const /*noexcept*/ = 0;
   virtual int port() const /*noexcept*/ = 0;
   virtual int api_version() const /*noexcept*/ = 0;

--- a/src/include/cpp-client/http/http.h
+++ b/src/include/cpp-client/http/http.h
@@ -16,14 +16,27 @@
 
 namespace Ark {
 namespace Client {
-/***
- * Ark::Client::HTTP
- * @brief: Forward Delcaration
- **/
-class HTTP;
-/**/
 
-/***/
+class IHTTP {
+protected:
+  IHTTP() = default;
+
+public:
+  virtual const char* host() const /*noexcept*/ = 0;
+  virtual int port() const /*noexcept*/ = 0;
+  virtual int api_version() const /*noexcept*/ = 0;
+
+  virtual bool setHost(
+    const char *const newHost,
+    int newPort,
+    int api_version
+  ) = 0;
+
+  virtual std::string get(const char *const request) = 0;
+  virtual std::string post(const char *const request, const char *body) = 0;
+
+  /**/
+};
 
 /***
  * Ark::Client::AbstractHTTP
@@ -32,7 +45,7 @@ class HTTP;
  * entry point for integrating the HTTPClient
  * library for different boards/chipsets
  **/
-class AbstractHTTP
+class AbstractHTTP : public IHTTP
 {
     protected:
         char host_[17];
@@ -61,31 +74,15 @@ class AbstractHTTP
         virtual ~AbstractHTTP() {};
 
         /**/
-        const char* host() const noexcept { return this->host_; };
-        int port() const noexcept { return this->port_; };
-        int api_version() const noexcept { return this->api_version_; }
-
-        /**/
-
-        virtual std::string get(
-                const char *const request
-        ) = 0;
-
-        /**/
-
-        virtual std::string post(
-                const char *const request,
-                const char *body
-        ) = 0;
-
-        /**/
-
+        const char* host() const /*noexcept*/ override { return this->host_; };
+        int port() const /*noexcept*/ override { return this->port_; };
+        int api_version() const /*noexcept*/ override { return this->api_version_; }
 
         bool setHost(
                 const char *const newHost,
                 int newPort,
                 int api_version
-        ) {
+        ) override {
             strncpy(this->host_, newHost, sizeof(this->host_) / sizeof(this->host_[0]));
             this->port_ = newPort;
             this->api_version_ = api_version;
@@ -99,47 +96,11 @@ class AbstractHTTP
 /***
  * HTTP object factory
  **/
-std::unique_ptr<AbstractHTTP> makeHTTP();
+std::unique_ptr<IHTTP> makeHTTP();
 /**/
 
+
 };
-};
-
-/***
- * Ark::Client::HTTP
- **/
-class Ark::Client::HTTP
-{
-private:
-  std::unique_ptr<Ark::Client::AbstractHTTP> http;
-
-public:
-  HTTP() : http(makeHTTP()) { }
-
-  const char* host() const noexcept { return http->host(); };
-  int port() const noexcept { return http->port(); };
-  int api_version() const noexcept { return http->api_version(); };
-
-  void setHostHTTP(
-          const char* const newHost,
-          int newPort,
-          int api_version
-  ) {
-      http->setHost(newHost, newPort, api_version);
-  }
-
-  std::string get(
-    const char* const request
-  ) {
-    return http->get(request);
-  }
-
-  std::string post(
-    const char* const request,
-    const char* body
-  ) {
-    return http->post(request, body);
-  }
 };
 /**/
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ project(Ark-Cpp-Client-tests)
 hunter_add_package(GTest)
 
 find_package(GTest CONFIG REQUIRED)
+find_package(GMock CONFIG REQUIRED)
 
 include(CTest)
 enable_testing()
@@ -38,7 +39,7 @@ add_executable(Ark-Cpp-Client-tests
 	${TEST_API_SRC}
 )
 
-target_link_libraries(Ark-Cpp-Client-tests Ark-Cpp-Client-lib GTest::gtest GTest::main)
+target_link_libraries(Ark-Cpp-Client-tests Ark-Cpp-Client-lib GTest::gtest GMock::gmock GMock::main)
 
 add_test(NAME test COMMAND Ark-Cpp-Client-tests)
 

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -595,14 +595,43 @@ TEST(api, test_blocks_search)
     JsonObject& dataZero = root["data"][0];
 
     const char* id = dataZero["id"];
-    ASSERT_STREQ("8337447655053578871", id);
+    ASSERT_STREQ("57415c61e6e7f10a6f9820d5124b3916f3c3a036b360f4802f0eb484f86f3369", id);
 
-    const char* previous = dataZero["previous"];
-    ASSERT_STREQ("6440284271011893973", previous);
+    const char* blockId = dataZero["blockId"];
+    ASSERT_STREQ("14126007750611341900", blockId);
 
+    int type = dataZero["type"];
+    ASSERT_EQ(0, type);
 
-    JsonObject& generator = dataZero["generator"];
+    uint64_t amount = dataZero["amount"];
+    ASSERT_TRUE(1000000000000000ull == amount);
 
-    const char* username = generator["username"];
-    ASSERT_STREQ("genesis_46", username);
+    uint64_t fee = dataZero["fee"];
+    ASSERT_TRUE(10000000ull == fee);
+
+    const char* sender = dataZero["sender"];
+    ASSERT_STREQ("DGihocTkwDygiFvmg6aG8jThYTic47GzU9", sender);
+
+    const char* recipient = dataZero["recipient"];
+    ASSERT_STREQ("DRac35wghMcmUSe5jDMLBDLWkVVjyKZFxK", recipient);
+
+    const char* signature = dataZero["signature"];
+    ASSERT_STREQ("3045022100878335a71ab6769f3c1e2895041ad24d6c58cdcfe1151c639e65289e5287b0a8022010800bcfdc3223a9c59a6b014e8adf72f1c34df8a46afe655b021930b03e214e", signature);
+
+    const char* vendorField = dataZero["vendorField"];
+    ASSERT_STREQ("yo", vendorField);
+
+    int confirmations = dataZero["confirmations"];
+    ASSERT_EQ(3034848, confirmations);
+
+    JsonObject& timestamp = dataZero["timestamp"];
+
+    uint64_t epoch = timestamp["epoch"];
+    ASSERT_TRUE(3909196ull == epoch);
+
+    int64_t unix = timestamp["unix"];
+    ASSERT_TRUE(1494010396ull == unix);
+
+    const char* human = timestamp["human"];
+    ASSERT_STREQ("2017-05-05T18:53:16Z", human);
 }

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -226,6 +226,12 @@ TEST(api, test_block_transactions)
 
     const auto blockTransactionsResponse = connection.api.blocks.transactions("14126007750611341900");
 
+    EXPECT_CALL(connection.api.blocks, transactions("14126007750611341900"))
+      .Times(1)
+      .WillOnce(Return(expected_response));
+
+    const auto blockTransactionsResponse = connection.api.blocks.transactions("14126007750611341900");
+
     DynamicJsonBuffer jsonBuffer(blockTransactionsResponse.size());
     JsonObject& root = jsonBuffer.parseObject(blockTransactionsResponse);
 

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -571,11 +571,17 @@ TEST(api, test_blocks_search)
         ]
     })";
 
-    EXPECT_CALL(connection.api.blocks, search(std::make_pair("id", "8337447655053578871"), 5, 1))
+    const std::map<std::string, std::string> body = {
+      {"id", "8337447655053578871"},
+      {"previousBlock", "6440284271011893973"},
+      {"version", "0"}
+    };
+
+    EXPECT_CALL(connection.api.blocks, search(_, _, _))
       .Times(1)
       .WillOnce(Return(expected_response));
 
-    const auto walletsSearch = connection.api.blocks.search(std::make_pair("id", "8337447655053578871"), 5, 1);
+    const auto walletsSearch = connection.api.blocks.search(body, 5, 1);
 
     DynamicJsonBuffer jsonBuffer(walletsSearch.size());
     JsonObject& root = jsonBuffer.parseObject(walletsSearch);

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -1,9 +1,13 @@
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "arkClient.h"
+#include "mocks/mock_api.h"
 #include "utils/json.h"
 
-/* test_blocks_block
+using testing::Return;
+
+/* test_two_blocks_block
  * https://dexplorer.ark.io:8443/api/v2/blocks/13114381566690093367
  * Expected Response:
     {
@@ -38,12 +42,46 @@
  */
 TEST(api, test_block)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto blockResponse = connection.api.blocks.get("13114381566690093367");
+    const std::string expected_response = R"({
+        "data": {
+            "id": "58328125061111756",
+            "version": 0,
+            "height": 3035362,
+            "previous": "3741191868092856237",
+            "forged": {
+                "reward": 200000000,
+                "fee": 0,
+                "total": 200000000
+            },
+            "payload": {
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "length": 0
+            },
+            "generator": {
+                "username": "genesis_6",
+                "address": "D5e2FzTPqdEHridjzpFZCCVyepAu6Vpmk4",
+                "publicKey": "023e577a7b3362e0aba70e6911d230e86d729b4cb640f0e0b25637b812a3e38b53"
+            },
+            "signature": "3044022047aeb0c9cfbb5709aba4c177009bfdc7804ef597073fb9ca6cb614d7e3d1af2d02207234119d02ca26600ece045c59266945081b4c8237370576aaad7c61a09fe0ad",
+            "transactions": 0,
+            "timestamp": {
+                "epoch": 32816544,
+                "unix": 1522917744,
+                "human": "2018-04-05T08:42:24Z"
+            }
+        }
+    })";
+
+    EXPECT_CALL(connection.api.blocks, get("58328125061111756"))
+      .Times(1)
+      .WillOnce(Return(expected_response));
+
+    const auto blockResponse = connection.api.blocks.get("58328125061111756");
 
     DynamicJsonBuffer jsonBuffer(blockResponse.size());
     JsonObject& root = jsonBuffer.parseObject(blockResponse);
@@ -145,12 +183,48 @@ TEST(api, test_block)
  */
 TEST(api, test_block_transactions)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto blockTransactionsResponse = connection.api.blocks.transactions("9269622721511437262");
+    const std::string expected_response = R"({
+        "meta": {
+            "count": 1,
+            "pageCount": 1,
+            "totalCount": 1,
+            "next": null,
+            "previous": null,
+            "self": "/v2/blocks/14126007750611341900/transactions?page=1",
+            "first": "/v2/blocks/14126007750611341900/transactions?page=1",
+            "last": "/v2/blocks/14126007750611341900/transactions?page=1"
+        },
+        "data": [
+            {
+                "id": "57415c61e6e7f10a6f9820d5124b3916f3c3a036b360f4802f0eb484f86f3369",
+                "blockId": "14126007750611341900",
+                "type": 0,
+                "amount": 1000000000000000,
+                "fee": 10000000,
+                "sender": "DGihocTkwDygiFvmg6aG8jThYTic47GzU9",
+                "recipient": "DRac35wghMcmUSe5jDMLBDLWkVVjyKZFxK",
+                "signature": "3045022100878335a71ab6769f3c1e2895041ad24d6c58cdcfe1151c639e65289e5287b0a8022010800bcfdc3223a9c59a6b014e8adf72f1c34df8a46afe655b021930b03e214e",
+                "vendorField": "yo",
+                "confirmations": 3034848,
+                "timestamp": {
+                    "epoch": 3909196,
+                    "unix": 1494010396,
+                    "human": "2017-05-05T18:53:16Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.blocks, transactions("14126007750611341900"))
+      .Times(1)
+      .WillOnce(Return(expected_response));
+
+    const auto blockTransactionsResponse = connection.api.blocks.transactions("14126007750611341900");
 
     DynamicJsonBuffer jsonBuffer(blockTransactionsResponse.size());
     JsonObject& root = jsonBuffer.parseObject(blockTransactionsResponse);
@@ -253,12 +327,58 @@ TEST(api, test_block_transactions)
  */
 TEST(api, test_blocks)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto blocksResponse = connection.api.blocks.all();
+    const std::string expected_response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 1517682,
+            "totalCount": 3035363,
+            "next": "/v2/blocks?limit=2&page=2",
+            "previous": null,
+            "self": "/v2/blocks?limit=2&page=1",
+            "first": "/v2/blocks?limit=2&page=1",
+            "last": "/v2/blocks?limit=2&page=1517682"
+        },
+        "data": [
+            {
+                "id": "6402736103893238690",
+                "version": 0,
+                "height": 3035363,
+                "previous": "58328125061111756",
+                "forged": {
+                    "reward": 200000000,
+                    "fee": 0,
+                    "total": 200000000
+                },
+                "payload": {
+                    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    "length": 0
+                },
+                "generator": {
+                    "username": "shawmishrak",
+                    "address": "D7P41dV7s259L3P7BVPNyqExqNDC7vdfx9",
+                    "publicKey": "030fa94238eb63db0247a9bd6a3fd810f690b449ee9ce4eb654b94b22875a9a612"
+                },
+                "signature": "304402204d0dbeb4e71a99a0f128a3480350014f0a9f250818dae908edd15bce99f49be00220257bf240c5d8578e9ffe144e7dbf0c2259d34e6571e6a83402edc01daec6228e",
+                "transactions": 0,
+                "timestamp": {
+                    "epoch": 32816552,
+                    "unix": 1522917752,
+                    "human": "2018-04-05T08:42:32Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.blocks, all(5, 1))
+      .Times(1)
+      .WillOnce(Return(expected_response));
+
+    const auto blocksResponse = connection.api.blocks.all(5, 1);
 
     DynamicJsonBuffer jsonBuffer(blocksResponse.size());
     JsonObject& root = jsonBuffer.parseObject(blocksResponse);
@@ -284,77 +404,77 @@ TEST(api, test_blocks)
 /* test_blocks_blocks_limit_page
  * https://dexplorer.ark.io:8443/api/v2/blocks?limit=10&page=1
  * Expected Response:
-    {
-        "meta": {
-            "count": int,
-            "pageCount": int,
-            "totalCount": int,
-            "next": null,
-            "previous": null,
-            "self": "\api/v2/blocks?limit=10&page=1",
-            "first": "/api/v2/blocks?limit=10&page=1",
-            "last": "/api/v2/blocks?limit=10&page=1"
-        },
-        "data":
-        [
-            {
-                "id": "string",
-                "version": int,
-                "height": int,
-                "previous": "string",
-                "forged": {
-                    "reward": uint64_t,
-                    "fee": uint64_t,
-                    "total": uint64_t
-                },
-                "payload": {
-                    "hash": "string",
-                    "length": ing
-                },
-                "generator": {
-                    "username": "string",
-                    "address": "string",
-                    "publicKey": "string"
-                },
-                "signature": "string",
-                "transactions": ing,
-                "timestamp": {
-                    "epoch": int,
-                    "unix": int,
-                    "human": "string"
-                }
-            }
-        ]
-    }
+	{
+		"meta": {
+			"count": int,
+			"pageCount": int,
+			"totalCount": int,
+			"next": null,
+			"previous": null,
+			"self": "\api/v2/blocks?limit=10&page=1",
+			"first": "/api/v2/blocks?limit=10&page=1",
+			"last": "/api/v2/blocks?limit=10&page=1"
+		},
+		"data":
+		[
+			{
+				"id": "string",
+				"version": int,
+				"height": int,
+				"previous": "string",
+				"forged": {
+					"reward": uint64_t,
+					"fee": uint64_t,
+					"total": uint64_t
+				},
+				"payload": {
+					"hash": "string",
+					"length": ing
+				},
+				"generator": {
+					"username": "string",
+					"address": "string",
+					"publicKey": "string"
+				},
+				"signature": "string",
+				"transactions": ing,
+				"timestamp": {
+					"epoch": int,
+					"unix": int,
+					"human": "string"
+				}
+			}
+		]
+	}
  */
 TEST(api, test_blocks_limit_page)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+	Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
 
-    auto apiVersion = connection.api.version();
-    ASSERT_EQ(2, apiVersion);
+	auto apiVersion = connection.api.version();
+	ASSERT_EQ(2, apiVersion);
 
-    const auto blocksResponse = connection.api.blocks.all(5, 1);
+	const auto blocksResponse = connection.api.blocks.all(5, 1);
 
-    DynamicJsonBuffer jsonBuffer(blocksResponse.size());
-    JsonObject& root = jsonBuffer.parseObject(blocksResponse);
+	DynamicJsonBuffer jsonBuffer(blocksResponse.size());
+	JsonObject& root = jsonBuffer.parseObject(blocksResponse);
 
-    JsonObject& meta = root["meta"];
+	JsonObject& meta = root["meta"];
 
-    int count = meta["count"];
-    ASSERT_NE(0, count);
+	int count = meta["count"];
+	ASSERT_NE(0, count);
 
-    int pageCount = meta["pageCount"];
-    ASSERT_NE(0, pageCount);
+	int pageCount = meta["pageCount"];
+	ASSERT_NE(0, pageCount);
 
-    int totalCount = meta["totalCount"];
-    ASSERT_NE(0, totalCount);
+	int totalCount = meta["totalCount"];
+	ASSERT_NE(0, totalCount);
 
 
-    JsonObject& dataZero = root["data"][0];
+	JsonObject& dataZero = root["data"][0];
 
-    int version = dataZero["version"];
-    ASSERT_EQ(0, version);
+	int version = dataZero["version"];
+	ASSERT_EQ(0, version);
 }
 
 /* test_blocks_search
@@ -404,17 +524,48 @@ TEST(api, test_blocks_limit_page)
  */
 TEST(api, test_blocks_search)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const std::map<std::string, std::string> body = {
-      {"id", "8337447655053578871"},
-      {"previousBlock", "6440284271011893973"},
-      {"version", "0"}
-    };
-    const auto walletsSearch = connection.api.blocks.search(body);
+    const std::string expected_response = R"({
+        "meta": {
+            "count": 1,
+            "pageCount": 1,
+            "totalCount": 1,
+            "next": null,
+            "previous": null,
+            "self": "/v2/blocks/14126007750611341900/transactions/search?page=1",
+            "first": "/v2/blocks/14126007750611341900/transactions/search?page=1",
+            "last": "/v2/blocks/14126007750611341900/transactions/search?page=1"
+        },
+        "data": [
+            {
+                "id": "57415c61e6e7f10a6f9820d5124b3916f3c3a036b360f4802f0eb484f86f3369",
+                "blockId": "14126007750611341900",
+                "type": 0,
+                "amount": 1000000000000000,
+                "fee": 10000000,
+                "sender": "DGihocTkwDygiFvmg6aG8jThYTic47GzU9",
+                "recipient": "DRac35wghMcmUSe5jDMLBDLWkVVjyKZFxK",
+                "signature": "3045022100878335a71ab6769f3c1e2895041ad24d6c58cdcfe1151c639e65289e5287b0a8022010800bcfdc3223a9c59a6b014e8adf72f1c34df8a46afe655b021930b03e214e",
+                "vendorField": "yo",
+                "confirmations": 3034848,
+                "timestamp": {
+                    "epoch": 3909196,
+                    "unix": 1494010396,
+                    "human": "2017-05-05T18:53:16Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.blocks, search(std::make_pair("id", "8337447655053578871"), 5, 1))
+      .Times(1)
+      .WillOnce(Return(expected_response));
+
+    const auto walletsSearch = connection.api.blocks.search(std::make_pair("id", "8337447655053578871"), 5, 1);
 
     DynamicJsonBuffer jsonBuffer(walletsSearch.size());
     JsonObject& root = jsonBuffer.parseObject(walletsSearch);

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -6,6 +6,7 @@
 #include "utils/json.h"
 
 using testing::Return;
+using testing::_;
 
 /* test_two_blocks_block
  * https://dexplorer.ark.io:8443/api/v2/blocks/13114381566690093367
@@ -77,7 +78,7 @@ TEST(api, test_block)
         }
     })";
 
-    EXPECT_CALL(connection.api.blocks, get("58328125061111756"))
+    EXPECT_CALL(connection.api.blocks, get(_))
       .Times(1)
       .WillOnce(Return(expected_response));
 
@@ -89,62 +90,65 @@ TEST(api, test_block)
     JsonObject& data = root["data"];
 
     const char* id = data["id"];
-    ASSERT_STREQ("13114381566690093367", id);
+    ASSERT_STREQ("58328125061111756", id);
 
     int version = data["version"];
     ASSERT_EQ(0, version);
 
     int height = data["height"];
-    ASSERT_EQ(1, height);
+    ASSERT_EQ(3035362, height);
 
 
     JsonObject& forged = data["forged"];
 
     uint64_t reward = forged["reward"];
-    ASSERT_TRUE(reward >= 0);
+    ASSERT_TRUE(reward == 200000000);
 
     uint64_t fee = forged["fee"];
     ASSERT_TRUE(fee == 0);
 
     uint64_t total = forged["total"];
-    ASSERT_TRUE(total == 0);
+    ASSERT_TRUE(total == 200000000);
 
 
     JsonObject& payload = data["payload"];
 
     const char* hash = payload["hash"];
-    ASSERT_STREQ("2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867", hash);
+    ASSERT_STREQ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash);
 
     int length = payload["length"];
-    ASSERT_EQ(11395, length);
+    ASSERT_EQ(0, length);
 
 
     JsonObject& generator = data["generator"];
 
+    const char* username = generator["username"];
+    ASSERT_STREQ("genesis_6", username);
+
     const char* address = generator["address"];
-    ASSERT_STREQ("D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ax", address);
+    ASSERT_STREQ("D5e2FzTPqdEHridjzpFZCCVyepAu6Vpmk4", address);
 
     const char* publicKey = generator["publicKey"];
-    ASSERT_STREQ("03d3fdad9c5b25bf8880e6b519eb3611a5c0b31adebc8455f0e096175b28321aff", publicKey);
+    ASSERT_STREQ("023e577a7b3362e0aba70e6911d230e86d729b4cb640f0e0b25637b812a3e38b53", publicKey);
 
 
     const char* signature = data["signature"];
-    ASSERT_STREQ("3044022035694a9b99a9236655c658eb07fc3b02ce5edcc24b76424a7287c54ed3822b0602203621e92defb360490610f763d85e94c2db2807a4bd7756cc8a6a585463ef7bae", signature);
+    ASSERT_STREQ("3044022047aeb0c9cfbb5709aba4c177009bfdc7804ef597073fb9ca6cb614d7e3d1af2d02207234119d02ca26600ece045c59266945081b4c8237370576aaad7c61a09fe0ad", signature);
 
     int transactions = data["transactions"];
-    ASSERT_EQ(52, transactions);
+    ASSERT_EQ(0, transactions);
 
 
     JsonObject& timestamp = data["timestamp"];
 
     int epoch = timestamp["epoch"];
-    ASSERT_EQ(0, epoch);
+    ASSERT_EQ(32816544, epoch);
 
     int timestampUnix = timestamp["unix"];
-    ASSERT_EQ(1490101200, timestampUnix);
+    ASSERT_EQ(1522917744, timestampUnix);
 
     const char* human = timestamp["human"];
-    ASSERT_STREQ("2017-03-21T13:00:00.000Z", human);
+    ASSERT_STREQ("2018-04-05T08:42:24Z", human);
 }
 
 /* test_blocks_block_transactions
@@ -220,7 +224,7 @@ TEST(api, test_block_transactions)
         ]
     })";
 
-    EXPECT_CALL(connection.api.blocks, transactions("14126007750611341900"))
+    EXPECT_CALL(connection.api.blocks, transactions(_))
       .Times(1)
       .WillOnce(Return(expected_response));
 
@@ -238,52 +242,52 @@ TEST(api, test_block_transactions)
     JsonObject& meta = root["meta"];
 
     int count = meta["count"];
-    ASSERT_EQ(0, count);
+    ASSERT_EQ(1, count);
 
     int pageCount = meta["pageCount"];
-    ASSERT_EQ(0, pageCount);
+    ASSERT_EQ(1, pageCount);
 
     int totalCount = meta["totalCount"];
-    ASSERT_EQ(0, totalCount);
+    ASSERT_EQ(1, totalCount);
 
 
     JsonObject& dataZero = root["data"][0];
 
-    int id = dataZero["id"];
-    ASSERT_EQ(0, id);
+    const char* id = dataZero["id"];
+    ASSERT_STREQ("57415c61e6e7f10a6f9820d5124b3916f3c3a036b360f4802f0eb484f86f3369", id);
 
     const char* blockId = dataZero["blockId"];
-    ASSERT_STRNE("", blockId);
+    ASSERT_STREQ("14126007750611341900", blockId);
 
     int type = dataZero["type"];
     ASSERT_EQ(0, type);
 
     uint64_t amount = dataZero["amount"];
-    ASSERT_TRUE(amount >= 0);
+    ASSERT_TRUE(amount = 1000000000000000);
 
     uint64_t fee = dataZero["fee"];
-    ASSERT_TRUE(fee >= 0);
+    ASSERT_TRUE(fee == 10000000);
 
     const char* sender = dataZero["sender"];
-    ASSERT_STRNE("", sender);
+    ASSERT_STREQ("DGihocTkwDygiFvmg6aG8jThYTic47GzU9", sender);
 
     const char* signature = dataZero["signature"];
-    ASSERT_STRNE("", signature);
+    ASSERT_STREQ("3045022100878335a71ab6769f3c1e2895041ad24d6c58cdcfe1151c639e65289e5287b0a8022010800bcfdc3223a9c59a6b014e8adf72f1c34df8a46afe655b021930b03e214e", signature);
 
     int confirmations = dataZero["confirmations"];
-    ASSERT_EQ(0, confirmations);
+    ASSERT_EQ(3034848, confirmations);
 
 
     JsonObject& timestamp = dataZero["timestamp"];
 
     int epoch = timestamp["epoch"];
-    ASSERT_EQ(0, epoch);
+    ASSERT_EQ(3909196, epoch);
 
     int timestampUnix = timestamp["unix"];
-    ASSERT_EQ(0, timestampUnix);
+    ASSERT_EQ(1494010396, timestampUnix);
 
     const char* human = timestamp["human"];
-    ASSERT_STRNE("", human);
+    ASSERT_STREQ("2017-05-05T18:53:16Z", human);
 }
 
 /* test_blocks_blocks

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -629,8 +629,8 @@ TEST(api, test_blocks_search)
     uint64_t epoch = timestamp["epoch"];
     ASSERT_TRUE(3909196ull == epoch);
 
-    uint64_t unix = timestamp["unix"];
-    ASSERT_TRUE(1494010396ull == unix);
+    uint64_t unix_timestamp = timestamp["unix"];
+    ASSERT_TRUE(1494010396ull == unix_timestamp);
 
     const char* human = timestamp["human"];
     ASSERT_STREQ("2017-05-05T18:53:16Z", human);

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -230,12 +230,6 @@ TEST(api, test_block_transactions)
 
     const auto blockTransactionsResponse = connection.api.blocks.transactions("14126007750611341900");
 
-    EXPECT_CALL(connection.api.blocks, transactions("14126007750611341900"))
-      .Times(1)
-      .WillOnce(Return(expected_response));
-
-    const auto blockTransactionsResponse = connection.api.blocks.transactions("14126007750611341900");
-
     DynamicJsonBuffer jsonBuffer(blockTransactionsResponse.size());
     JsonObject& root = jsonBuffer.parseObject(blockTransactionsResponse);
 

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -629,7 +629,7 @@ TEST(api, test_blocks_search)
     uint64_t epoch = timestamp["epoch"];
     ASSERT_TRUE(3909196ull == epoch);
 
-    int64_t unix = timestamp["unix"];
+    uint64_t unix = timestamp["unix"];
     ASSERT_TRUE(1494010396ull == unix);
 
     const char* human = timestamp["human"];

--- a/test/api/delegates.cpp
+++ b/test/api/delegates.cpp
@@ -1,9 +1,13 @@
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "arkClient.h"
+#include "mocks/mock_api.h"
 #include "utils/json.h"
 
-/* test_delegates_delegate
+using testing::Return;
+
+/* test_two_delegates_delegate
  * https://dexplorer.ark.io:8443/api/v2/delegates/boldninja
  * Expected Response:
     {
@@ -34,10 +38,40 @@
  */
 TEST(api, test_delegate)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string expected_response = R"({
+        "data": {
+            "username": "boldninja",
+            "address": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+            "publicKey": "022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d",
+            "votes": 0,
+            "rank": 29,
+            "blocks": {
+                "produced": 0,
+                "missed": 0,
+                "last": {
+                    "id": "10652480998435361357",
+                    "timestamp": {
+                        "epoch": 32816112,
+                        "unix": 1522917312,
+                        "human": "2018-04-05T08:35:12Z"
+                    }
+                }
+            },
+            "production": {
+                "approval": "0.10",
+                "productivity": "0.00"
+            }
+        }
+    })";
+
+    EXPECT_CALL(connection.api.delegates, get("boldninja"))
+      .Times(1)
+      .WillOnce(Return(expected_response));
 
     const auto delegateResponse = connection.api.delegates.get("boldninja");
 
@@ -137,7 +171,53 @@ TEST(api, test_delegate)
  */
 TEST(api, test_delegate_blocks)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
+
+    const std::string expected_response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 29919,
+            "totalCount": 59838,
+            "next": "/v2/delegates/boldninja/blocks?page=2",
+            "previous": null,
+            "self": "/v2/delegates/boldninja/blocks?page=1",
+            "first": "/v2/delegates/boldninja/blocks?page=1",
+            "last": "/v2/delegates/boldninja/blocks?page=29919"
+        },
+        "data": [
+            {
+                "id": "10652480998435361357",
+                "version": 0,
+                "height": 3035318,
+                "previous": "12548322724277171379",
+                "forged": {
+                    "reward": 200000000,
+                    "fee": 0,
+                    "total": 200000000
+                },
+                "payload": {
+                    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    "length": 0
+                },
+                "generator": {
+                    "username": "boldninja",
+                    "address": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                    "publicKey": "022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d"
+                },
+                "signature": "3044022034e754a3ff70adba6323517e1297c6a9f30176df2ac589661e9206fe60a203120220182c38da201fee20e803bb7725fe9618d6707547e6d7b757d4108f546934fe1c",
+                "transactions": 0,
+                "timestamp": {
+                    "epoch": 32816112,
+                    "unix": 1522917312,
+                    "human": "2018-04-05T08:35:12Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.delegates, blocks("boldninja", 3, 1))
+      .Times(1)
+      .WillOnce(Return(expected_response));
 
     const auto delegateBlocksResponse = connection.api.delegates.blocks("boldninja", 3, 1);
 
@@ -205,10 +285,35 @@ TEST(api, test_delegate_blocks)
  */
 TEST(api, test_delegate_voters)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string expected_response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 10,
+            "totalCount": 19,
+            "next": "/v2/delegates/boldninja/voters?page=2",
+            "previous": null,
+            "self": "/v2/delegates/boldninja/voters?page=1",
+            "first": "/v2/delegates/boldninja/voters?page=1",
+            "last": "/v2/delegates/boldninja/voters?page=10"
+        },
+        "data": [
+            {
+                "address": "D5mbS6mpP5UheuciNscpDLgC127kYjRtkK",
+                "publicKey": "03f7e0b1ab14985990416f72ed0b206c20b9efa35156e4528c8ff749fa0eea5d5a",
+                "balance": 400000000,
+                "isDelegate": false
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.delegates, voters("boldninja", 5, 1))
+      .Times(1)
+      .WillOnce(Return(expected_response));
 
     const auto delegateVotersResponse = connection.api.delegates.voters("boldninja", 5, 1);
 
@@ -282,10 +387,52 @@ TEST(api, test_delegate_voters)
  */
 TEST(api, test_delegates)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string expected_response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 99,
+            "totalCount": 197,
+            "next": "/v2/delegates?page=2",
+            "previous": null,
+            "self": "/v2/delegates?page=1",
+            "first": "/v2/delegates?page=1",
+            "last": "/v2/delegates?page=99"
+        },
+        "data": [
+            {
+                "username": "dark_jmc",
+                "address": "D5PXQVeJmchVrZFHL7cALZK8mWWzjCaVfz",
+                "publicKey": "02a9a0ac34a94f9d27fd9b4b56eb3c565a9a3f61e660f269775fb456f7f3301586",
+                "votes": 0,
+                "rank": 1,
+                "blocks": {
+                    "produced": 0,
+                    "missed": 0,
+                    "last": {
+                        "id": "12383884455448354193",
+                        "timestamp": {
+                            "epoch": 31784600,
+                            "unix": 1521885800,
+                            "human": "2018-03-24T10:03:20Z"
+                        }
+                    }
+                },
+                "production": {
+                    "approval": "0.08",
+                    "productivity": "0.00"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.delegates, all(5, 1))
+      .Times(1)
+      .WillOnce(Return(expected_response));
 
     const auto delegates = connection.api.delegates.all(5, 1);
 

--- a/test/api/delegates.cpp
+++ b/test/api/delegates.cpp
@@ -115,8 +115,8 @@ TEST(api, test_delegate)
     uint64_t epoch = timestamp["epoch"];
     ASSERT_TRUE(32816112ull == epoch);
 
-    uint64_t unix = timestamp["unix"];
-    ASSERT_TRUE(1522917312ull == unix);
+    uint64_t unix_timestamp = timestamp["unix"];
+    ASSERT_TRUE(1522917312ull == unix_timestamp);
 
     const char* human = timestamp["human"];
     ASSERT_STREQ("2018-04-05T08:35:12Z", human);

--- a/test/api/delegates.cpp
+++ b/test/api/delegates.cpp
@@ -105,7 +105,7 @@ TEST(api, test_delegate)
     int missed = blocks["missed"];
     ASSERT_EQ(0, missed);
 
-    JsonObject& last = data["last"];
+    JsonObject& last = blocks["last"];
 
     const char* last_id = last["id"];
     ASSERT_STREQ("10652480998435361357", last_id);

--- a/test/api/delegates.cpp
+++ b/test/api/delegates.cpp
@@ -6,6 +6,7 @@
 #include "utils/json.h"
 
 using testing::Return;
+using testing::_;
 
 /* test_two_delegates_delegate
  * https://dexplorer.ark.io:8443/api/v2/delegates/boldninja
@@ -69,7 +70,7 @@ TEST(api, test_delegate)
         }
     })";
 
-    EXPECT_CALL(connection.api.delegates, get("boldninja"))
+    EXPECT_CALL(connection.api.delegates, get(_))
       .Times(1)
       .WillOnce(Return(expected_response));
 
@@ -84,34 +85,50 @@ TEST(api, test_delegate)
     ASSERT_STREQ("boldninja", username);
 
     const char* address = data["address"];
-    ASSERT_STREQ("DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu", address);
+    ASSERT_STREQ("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", address);
 
     const char* publicKey = data["publicKey"];
-    ASSERT_STREQ("023ee98f453661a1cb765fd60df95b4efb1e110660ffb88ae31c2368a70f1f7359", publicKey);
+    ASSERT_STREQ("022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d", publicKey);
 
     uint64_t votes = data["votes"];
-    ASSERT_GE(votes, 0);
+    ASSERT_EQ(0, votes);
 
     int rank = data["rank"];
-    ASSERT_NE(0, rank);
+    ASSERT_EQ(29, rank);
 
 
     JsonObject& blocks = data["blocks"];
 
     int produced = blocks["produced"];
-    ASSERT_NE(0, produced);
+    ASSERT_EQ(0, produced);
 
     int missed = blocks["missed"];
-    ASSERT_GE(missed, 0);
+    ASSERT_EQ(0, missed);
+
+    JsonObject& last = data["last"];
+
+    const char* last_id = last["id"];
+    ASSERT_STREQ("10652480998435361357", last_id);
+
+    JsonObject& timestamp = last["timestamp"];
+
+    uint64_t epoch = timestamp["epoch"];
+    ASSERT_TRUE(32816112ull == epoch);
+
+    uint64_t unix = timestamp["unix"];
+    ASSERT_TRUE(1522917312ull == unix);
+
+    const char* human = timestamp["human"];
+    ASSERT_STREQ("2018-04-05T08:35:12Z", human);
 
 
     JsonObject& production = data["production"];
 
     double approval = production["approval"];
-    ASSERT_NE(100.00, approval);
+    ASSERT_EQ(0.10, approval);
 
     double productivity = production["productivity"];
-    ASSERT_NE(100.00, productivity);
+    ASSERT_EQ(0.0, productivity);
 }
 
 /* test_delegates_delegate_blocks
@@ -215,7 +232,7 @@ TEST(api, test_delegate_blocks)
         ]
     })";
 
-    EXPECT_CALL(connection.api.delegates, blocks("boldninja", 3, 1))
+    EXPECT_CALL(connection.api.delegates, blocks(_, _, _))
       .Times(1)
       .WillOnce(Return(expected_response));
 
@@ -227,34 +244,34 @@ TEST(api, test_delegate_blocks)
     JsonObject& meta = root["meta"];
 
     int count = meta["count"];
-    ASSERT_NE(0, count);
+    ASSERT_EQ(2, count);
 
     int pageCount = meta["pageCount"];
-    ASSERT_NE(0, pageCount);
+    ASSERT_EQ(29919, pageCount);
 
     int totalCount = meta["totalCount"];
-    ASSERT_NE(0, totalCount);
+    ASSERT_EQ(59838, totalCount);
 
     const char* id = root["data"][0]["id"];
-    ASSERT_STRNE("", id);
+    ASSERT_STREQ("10652480998435361357", id);
 
     int version = root["data"][0]["version"];
     ASSERT_EQ(0, version);
 
     uint64_t height = root["data"][0]["height"];
-    ASSERT_TRUE(height >= 0);
+    ASSERT_TRUE(3035318ull == height);
 
     const char* previous = root["data"][0]["previous"];
-    ASSERT_STRNE("0", previous);
+    ASSERT_STREQ("12548322724277171379", previous);
 
     const char* username = root["data"][0]["generator"]["username"];
     ASSERT_STREQ("boldninja", username);
 
     const char* address = root["data"][0]["generator"]["address"];
-    ASSERT_STREQ("DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu", address);
+    ASSERT_STREQ("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", address);
 
     const char* publicKey = root["data"][0]["generator"]["publicKey"];
-    ASSERT_STREQ("023ee98f453661a1cb765fd60df95b4efb1e110660ffb88ae31c2368a70f1f7359", publicKey);
+    ASSERT_STREQ("022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d", publicKey);
 }
 
 
@@ -311,7 +328,7 @@ TEST(api, test_delegate_voters)
         ]
     })";
 
-    EXPECT_CALL(connection.api.delegates, voters("boldninja", 5, 1))
+    EXPECT_CALL(connection.api.delegates, voters(_, _, _))
       .Times(1)
       .WillOnce(Return(expected_response));
 
@@ -335,13 +352,13 @@ TEST(api, test_delegate_voters)
     JsonObject& dataZero = root["data"][0];
 
     const char* address = dataZero["address"];
-    ASSERT_STRNE("", address);
+    ASSERT_STREQ("D5mbS6mpP5UheuciNscpDLgC127kYjRtkK", address);
 
     const char* publicKey = dataZero["publicKey"];
-    ASSERT_STRNE("", publicKey);
+    ASSERT_STREQ("03f7e0b1ab14985990416f72ed0b206c20b9efa35156e4528c8ff749fa0eea5d5a", publicKey);
 
     bool isDelegate = dataZero["isDelegate"];
-    ASSERT_TRUE(isDelegate || !isDelegate);
+    ASSERT_FALSE(isDelegate);
 }
 
 /* test_delegates_delegates
@@ -453,14 +470,14 @@ TEST(api, test_delegates)
     JsonObject& dataZero = root["data"][0];
 
     const char* username = dataZero["username"];
-    ASSERT_STRNE("", username);
+    ASSERT_STREQ("dark_jmc", username);
 
     const char* address = dataZero["address"];
-    ASSERT_STRNE("", address);
+    ASSERT_STREQ("D5PXQVeJmchVrZFHL7cALZK8mWWzjCaVfz", address);
 
     const char* publicKey = dataZero["publicKey"];
-    ASSERT_STRNE("", publicKey);
+    ASSERT_STREQ("02a9a0ac34a94f9d27fd9b4b56eb3c565a9a3f61e660f269775fb456f7f3301586", publicKey);
 
     uint64_t votes = dataZero["votes"];
-    ASSERT_TRUE(votes >= 0);
+    ASSERT_TRUE(0ull == votes);
 }

--- a/test/api/node.cpp
+++ b/test/api/node.cpp
@@ -1,9 +1,15 @@
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "mocks/mock_api.h"
+
 #include "arkClient.h"
 #include "utils/json.h"
 
-/* test_node_configuration
+using testing::Return;
+
+/* test_two_node_configuration
  * https://dexplorer.ark.io:8443/api/v2/node/configuration
  * Expected Response:
     {
@@ -99,10 +105,59 @@
 */
 TEST(api, test_node_configuration)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.54", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+          "data": {
+          "nethash": "578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23",
+            "token" : "DARK",
+            "symbol" : "DѦ",
+            "explorer" : "https://dexplorer.ark.io",
+            "version" : 30,
+            "ports" : {
+            "@arkecosystem/core-p2p": 4000,
+              "@arkecosystem/core-api" : 4003,
+              "@arkecosystem/core-graphql" : 4005,
+              "@arkecosystem/core-json-rpc" : 8080
+          },
+            "feeStatistics": [
+            {
+              "type": 0,
+                "fees" : {
+                "minFee": 268421,
+                  "maxFee" : 597781,
+                  "avgFee" : 404591
+              }
+            }
+            ],
+              "constants": {
+              "height": 75600,
+                "reward" : 200000000,
+                "activeDelegates" : 51,
+                "blocktime" : 8,
+                "block" : {
+                "version": 0,
+                  "maxTransactions" : 50,
+                  "maxPayload" : 2097152
+              },
+                "epoch" : "2017-03-21T13:00:00.000Z",
+                  "fees" : {
+                  "send": 10000000,
+                    "vote" : 100000000,
+                    "secondsignature" : 500000000,
+                    "delegate" : 2500000000,
+                    "multisignature" : 500000000
+                }
+            }
+        }
+    })";
+
+    EXPECT_CALL(connection.api.node, configuration())
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto nodeConfiguration = connection.api.node.configuration();
 
@@ -149,10 +204,22 @@ TEST(api, test_node_configuration)
  */
 TEST(api, test_node_status)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.54", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+        "data": {
+            "synced": false,
+            "now": 3034451,
+            "blocksCount": -36
+        }
+    })";
+
+    EXPECT_CALL(connection.api.node, status())
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto nodeStatus = connection.api.node.status();
 
@@ -185,10 +252,23 @@ TEST(api, test_node_status)
  */
 TEST(api, test_node_syncing)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.54", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+        "data": {
+            "syncing": true,
+            "blocks": -36,
+            "height": 3034451,
+            "id": "5444078994968869529"
+        }
+    })";
+
+    EXPECT_CALL(connection.api.node, syncing())
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto nodeSyncing = connection.api.node.syncing();
 

--- a/test/api/node.cpp
+++ b/test/api/node.cpp
@@ -167,13 +167,13 @@ TEST(api, test_node_configuration)
     JsonObject& data = root["data"];
 
     const char* nethash = data["nethash"];
-    ASSERT_STREQ("2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867", nethash);
+    ASSERT_STREQ("578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23", nethash);
 
     const char* token = data["token"];
     ASSERT_STREQ("DARK", token);
 
     const char* symbol = data["symbol"];
-    ASSERT_STREQ("D\xD1\xA6", symbol);
+    ASSERT_STREQ(u8"DѦ", symbol);
 
     const char* explorer = data["explorer"];
     ASSERT_STREQ("https://dexplorer.ark.io", explorer);
@@ -185,7 +185,7 @@ TEST(api, test_node_configuration)
     JsonObject& ports = data["ports"];
 
     int core_p2p = ports["@arkecosystem/core-p2p"];
-    ASSERT_EQ(4002, core_p2p);
+    ASSERT_EQ(4000, core_p2p);
 
     int core_api = ports["@arkecosystem/core-api"];
     ASSERT_EQ(4003, core_api);
@@ -213,7 +213,7 @@ TEST(api, test_node_status)
         "data": {
             "synced": false,
             "now": 3034451,
-            "blocksCount": -36
+            "blocksCount": 36
         }
     })";
 
@@ -229,13 +229,13 @@ TEST(api, test_node_status)
     JsonObject& data = root["data"];
 
     bool synced = data["synced"];
-    ASSERT_TRUE(synced || !synced);
+    ASSERT_FALSE(synced);
 
     int now = data["now"];
-    ASSERT_GE(now, 0);
+    ASSERT_EQ(3034451, now);
 
-    const char* blocksCount = data["blocksCount"];
-    ASSERT_STRNE("", blocksCount);
+    int blocksCount = data["blocksCount"];
+    ASSERT_EQ(36, blocksCount);
 }
 
 /* test_node_status
@@ -260,7 +260,7 @@ TEST(api, test_node_syncing)
     const std::string response = R"({
         "data": {
             "syncing": true,
-            "blocks": -36,
+            "blocks": 36,
             "height": 3034451,
             "id": "5444078994968869529"
         }
@@ -278,14 +278,14 @@ TEST(api, test_node_syncing)
     JsonObject& data = root["data"];
 
     bool syncing = data["syncing"];
-    ASSERT_TRUE(syncing || !syncing);
+    ASSERT_TRUE(syncing);
 
-    const char* blocks = data["blocks"];
-    ASSERT_STRNE("", blocks);
+    int blocks = data["blocks"];
+    ASSERT_EQ(36, blocks);
 
     uint64_t height = data["height"];
-    ASSERT_TRUE(height >= 0);
+    ASSERT_TRUE(3034451ull == height);
 
     const char* id = data["id"];
-    ASSERT_STRNE("", id);
+    ASSERT_STREQ("5444078994968869529", id);
 }

--- a/test/api/peers.cpp
+++ b/test/api/peers.cpp
@@ -1,9 +1,15 @@
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "mocks/mock_api.h"
+
 #include "arkClient.h"
 #include "utils/json.h"
 
-/* test_peers_peer
+using testing::Return;
+
+/* test_two_peers_peer
  * https://dexplorer.ark.io:8443/api/v2/peers/167.114.29.54
  * Expected Response:
     {
@@ -19,10 +25,24 @@
  */
 TEST(api, test_peer)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.54", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+        "data": {
+            "ip": "167.114.29.55",
+            "port": 4002,
+            "version": "1.1.1",
+            "status": "OK",
+            "latency": 355
+        }
+    })";
+
+    EXPECT_CALL(connection.api.peers, get("167.114.29.49"))
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto peer = connection.api.peers.get("167.114.29.49");
 
@@ -78,10 +98,36 @@ TEST(api, test_peer)
  */
 TEST(api, test_peers)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 1,
+            "totalCount": 2,
+            "next": null,
+            "previous": null,
+            "self": "/v2/peers?page=1",
+            "first": "/v2/peers?page=1",
+            "last": "/v2/peers?page=1"
+        },
+        "data": [
+            {
+                "ip": "167.114.29.53",
+                "port": 4002,
+                "version": "1.1.1",
+                "status": "OK",
+                "latency": 1390
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.peers, all(5, 1))
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto peers = connection.api.peers.all(5, 1);
 

--- a/test/api/peers.cpp
+++ b/test/api/peers.cpp
@@ -8,6 +8,7 @@
 #include "utils/json.h"
 
 using testing::Return;
+using testing::_;
 
 /* test_two_peers_peer
  * https://dexplorer.ark.io:8443/api/v2/peers/167.114.29.54
@@ -35,12 +36,13 @@ TEST(api, test_peer)
             "ip": "167.114.29.55",
             "port": 4002,
             "version": "1.1.1",
-            "status": "OK",
+            "status": 200,
+            "os": "linux",
             "latency": 355
         }
     })";
 
-    EXPECT_CALL(connection.api.peers, get("167.114.29.49"))
+    EXPECT_CALL(connection.api.peers, get(_))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -52,13 +54,13 @@ TEST(api, test_peer)
     JsonObject& data = root["data"];
 
     const char* ip = data["ip"];
-    ASSERT_STREQ("167.114.29.49", ip);
+    ASSERT_STREQ("167.114.29.55", ip);
 
     int port = data["port"];
     ASSERT_EQ(4002, port);
 
     const char* version = data["version"];
-    ASSERT_STRNE("", version);
+    ASSERT_STREQ("1.1.1", version);
 
     int status = data["status"];
     ASSERT_EQ(200, status);
@@ -67,7 +69,7 @@ TEST(api, test_peer)
     ASSERT_STREQ("linux", os);
 
     int latency = data["latency"];
-    ASSERT_NE(0, latency);
+    ASSERT_EQ(355, latency);
 }
 
 /* test_peers_peers
@@ -119,13 +121,14 @@ TEST(api, test_peers)
                 "ip": "167.114.29.53",
                 "port": 4002,
                 "version": "1.1.1",
-                "status": "OK",
+                "status": 200,
+                "os": "linux",
                 "latency": 1390
             }
         ]
     })";
 
-    EXPECT_CALL(connection.api.peers, all(5, 1))
+    EXPECT_CALL(connection.api.peers, all(_, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -149,17 +152,20 @@ TEST(api, test_peers)
     JsonObject& dataZero = root["data"][0];
 
     const char* ip = dataZero["ip"];
-    ASSERT_STRNE("", ip);
+    ASSERT_STREQ("167.114.29.53", ip);
 
     int port = dataZero["port"];
     ASSERT_EQ(4002, port);
 
     const char* version = dataZero["version"];
-    ASSERT_STRNE("", version);
+    ASSERT_STREQ("1.1.1", version);
+
+    int status = dataZero["status"];
+    ASSERT_EQ(200, status);
 
     const char* os = dataZero["os"];
-    ASSERT_STRNE("", os);
+    ASSERT_STREQ("linux", os);
 
     int latency = dataZero["latency"];
-    ASSERT_NE(0, latency);
+    ASSERT_EQ(1390, latency);
 }

--- a/test/api/transactions.cpp
+++ b/test/api/transactions.cpp
@@ -8,6 +8,7 @@
 #include "utils/json.h"
 
 using testing::Return;
+using testing::_;
 
 /* test_two_transactions_transaction
  * https://dexplorer.ark.io:8443/api/v2/transactions/b324cea5c5a6c15e6ced3ec9c3135a8022eeadb8169f7ba66c80ebc82b0ac850
@@ -62,7 +63,7 @@ TEST(api, test_transaction)
         }
     })";
 
-    EXPECT_CALL(connection.api.transactions, get("5c6ce775447a5acd22050d72e2615392494953bb1fb6287e9ffb3c33eaeb79aa"))
+    EXPECT_CALL(connection.api.transactions, get(_))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -74,43 +75,43 @@ TEST(api, test_transaction)
     JsonObject& data = root["data"];
 
     const char* id = data["id"];
-    ASSERT_STREQ("b324cea5c5a6c15e6ced3ec9c3135a8022eeadb8169f7ba66c80ebc82b0ac850", id);
+    ASSERT_STREQ("5c6ce775447a5acd22050d72e2615392494953bb1fb6287e9ffb3c33eaeb79aa", id);
 
     const char* blockId = data["blockId"];
-    ASSERT_STREQ("4375573732170746923", blockId);
+    ASSERT_STREQ("4271682877946294396", blockId);
 
     int type = data["type"];
-    ASSERT_EQ(3, type);
+    ASSERT_EQ(0, type);
 
     uint64_t amount = data["amount"];
-    ASSERT_TRUE(amount == 0);
+    ASSERT_TRUE(amount == 32106400000);
 
     uint64_t fee = data["fee"];
-    ASSERT_TRUE(fee == 100000000);
+    ASSERT_TRUE(fee == 10000000);
 
     const char* sender = data["sender"];
-    ASSERT_STREQ("DKcFDN6mhLAheRAfmN6LT1e4AeyF1Fd9bY", sender);
+    ASSERT_STREQ("DDiTHZ4RETZhGxcyAi1VruCXZKxBFqXMeh", sender);
 
     const char* recipient = data["recipient"];
-    ASSERT_STREQ("DKcFDN6mhLAheRAfmN6LT1e4AeyF1Fd9bY", recipient);
+    ASSERT_STREQ("DQnQNoJuNCvpjYhxL7fsnGepHBqrumgsyP", recipient);
 
     const char* signature = data["signature"];
-    ASSERT_STREQ("3045022100dc27398f4f3a24e55dc1ee87900de988254daa3fed71e82f4d6ef85ed4f9d9f8022025d71158cc15672863b2263622026ec19fa9cc9d2e8c78fa79eb2d8f4ef45fc7", signature);
+    ASSERT_STREQ("3044022047c39f6f45a46a87f91ca867f9551dbebf0035adcfcbdc1370222c7a1517fc0002206fb5ecc10460e0352a8b626a508e2fcc76e39e490b0a2581dd772ebc8079696e", signature);
 
     int confirmations = data["confirmations"];
-    ASSERT_GT(confirmations, 0);
+    ASSERT_EQ(confirmations, 1928);
 
 
     JsonObject& timestamp = data["timestamp"];
 
     int epoch = timestamp["epoch"];
-    ASSERT_EQ(45024866, epoch);
+    ASSERT_EQ(32794053, epoch);
 
     int timestampUnix = timestamp["unix"];
-    ASSERT_EQ(1535126066, timestampUnix);
+    ASSERT_EQ(1522895253, timestampUnix);
 
     const char* human = timestamp["human"];
-    ASSERT_STREQ("2018-08-24T15:54:26.000Z", human);
+    ASSERT_STREQ("2018-04-05T02:27:33Z", human);
 }
 
 /* test_transactions_transaction_types
@@ -139,15 +140,15 @@ TEST(api, test_transaction_types)
 
     const std::string response = R"({
 			  "data": {
-			    "TRANSFER": 0,
-			    "SECOND_SIGNATURE": 1,
-			    "DELEGATE_REGISTRATION": 2,
-			    "VOTE": 3,
-			    "MULTI_SIGNATURE": 4,
-			    "IPFS": 5,
-			    "TIMELOCK_TRANSFER": 6,
-			    "MULTI_PAYMENT": 7,
-			    "DELEGATE_RESIGNATION": 8
+			    "Transfer": 0,
+			    "SecondSignature": 1,
+			    "DelegateRegistration": 2,
+			    "Vote": 3,
+			    "MultiSignature": 4,
+			    "Ipfs": 5,
+			    "TimelockTransfer": 6,
+			    "MultiPayment": 7,
+			    "DelegateResignation": 8
 			  }
 			})";
 
@@ -236,7 +237,7 @@ TEST(api, test_transaction_unconfirmed)
 			  }
 			})";
 
-    EXPECT_CALL(connection.api.transactions, getUnconfirmed("dummy"))
+    EXPECT_CALL(connection.api.transactions, getUnconfirmed(_))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -245,16 +246,48 @@ TEST(api, test_transaction_unconfirmed)
     DynamicJsonBuffer jsonBuffer(transactionUnconfirmed.size());
     JsonObject& root = jsonBuffer.parseObject(transactionUnconfirmed);
 
-    JsonObject& meta = root["meta"];
+    JsonObject& data = root["data"];
 
-    int count = meta["count"];
-    ASSERT_GE(count, 0);
+    const char* id = data["id"];
+    ASSERT_STREQ("dummy", id);
 
-    int pageCount = meta["pageCount"];
-    ASSERT_GE(pageCount, 0);
+    const char* blockId = data["blockId"];
+    ASSERT_STREQ("dummy", blockId);
 
-    int totalCount = meta["totalCount"];
-    ASSERT_GE(totalCount, 0);
+    int type = data["type"];
+    ASSERT_EQ(0, type);
+
+    uint64_t amount = data["amount"];
+    ASSERT_TRUE(10000000ull == amount);
+
+    uint64_t fee = data["fee"];
+    ASSERT_TRUE(10000000ull == fee);
+
+    const char* sender = data["sender"];
+    ASSERT_STREQ("dummy", sender);
+
+    const char* recipient = data["recipient"];
+    ASSERT_STREQ("dummy", recipient);
+
+    const char* signature = data["signature"];
+    ASSERT_STREQ("dummy", signature);
+
+    const char* vendorField = data["vendorField"];
+    ASSERT_STREQ("dummy", vendorField);
+
+    int confirmations = data["confirmations"];
+    ASSERT_EQ(10, confirmations);
+
+    JsonObject& timestamp = data["timestamp"];
+
+    uint64_t epoch = timestamp["epoch"];
+    ASSERT_TRUE(40505460ull == epoch);
+
+    uint64_t unix = timestamp["unix"];
+    ASSERT_TRUE(1530606660ull == unix);
+
+    const char* human = timestamp["human"];
+    ASSERT_STREQ("2018-07-03T08:31:00Z", human);
 }
 
 /* test_transactions_transactions
@@ -292,7 +325,7 @@ TEST(api, test_transaction_unconfirmed)
     ]
     }
  */
-#if 0
+
 TEST(api, test_transactions)
 {
     Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
@@ -331,7 +364,7 @@ TEST(api, test_transactions)
       ]
   })";
 
-    EXPECT_CALL(connection.api.transactions, all(2, 1)
+    EXPECT_CALL(connection.api.transactions, all(_, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -360,7 +393,6 @@ TEST(api, test_transactions)
     uint64_t fee = dataZero["fee"];
     ASSERT_TRUE(fee >= 0);
 }
-#endif
 
 /* test_transactions_transactions_unconfirmed
  * https://dexplorer.ark.io:8443/api/v2/transactions/unconfirmed?limit=2&page=1
@@ -420,7 +452,7 @@ TEST(api, test_transactions_unconfirmed)
       ]
       })";
 
-    EXPECT_CALL(connection.api.transactions, allUnconfirmed(5, 1))
+    EXPECT_CALL(connection.api.transactions, allUnconfirmed(_, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -441,37 +473,7 @@ TEST(api, test_transactions_unconfirmed)
     ASSERT_TRUE(totalCount >= 0);
 }
 
-/* test_two_transactions_transactions_search_all
- *
- * Expected Response:
- */
-TEST(api, test_two_transactions_search_all)
-{
-  Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
-
-  auto apiVersion = connection.api.version();
-  ASSERT_EQ(2, apiVersion);
-
-  const std::map<std::string, std::string> body = { };
-  const auto transactions = connection.api.transactions.search(body, 5, 1);
-
-  DynamicJsonBuffer jsonBuffer(transactions.size());
-  JsonObject& root = jsonBuffer.parseObject(transactions);
-
-  JsonObject& meta = root["meta"];
-
-  int count = meta["count"];
-  ASSERT_TRUE(count >= 0);
-
-  int pageCount = meta["pageCount"];
-  ASSERT_TRUE(pageCount >= 0);
-
-  int totalCount = meta["totalCount"];
-  ASSERT_TRUE(totalCount >= 0);
-}
-
-#if 0 // TODO
-/* test_two_transactions_transactions_search
+/* test_transactions_transactions_search
  * 
  * Expected Response:
  {
@@ -544,15 +546,14 @@ TEST(api, test_transactions_search)
 			  ]
 			})";
 
-    EXPECT_CALL(connection.api.transactions, search(5, 1))
+    EXPECT_CALL(connection.api.transactions, search(_, _, _))
       .Times(1)
       .WillOnce(Return(response));
 
-    const auto transactions = connection.api.transactions.get("4bbc5433e5a4e439369f1f57825e92d07cf9cb8e07aada69c122a2125e4b9d48", 5, 1);
-    const std::map<std::string, std::string> body = {
-      {"id", "927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37"}
-    };
-    const auto transactions = connection.api.transactions.search(body, 5, 1);
+  const std::map<std::string, std::string> body = {
+    {"id", "dummy"}
+  };
+  const auto transactions = connection.api.transactions.search(body, 5, 1);
 
 	DynamicJsonBuffer jsonBuffer(transactions.size());
 	JsonObject& root = jsonBuffer.parseObject(transactions);
@@ -571,18 +572,20 @@ TEST(api, test_transactions_search)
 	JsonObject& data = root["data"][0];
 
 	const char* id = data["id"];
-	ASSERT_STREQ("927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37", id);
+	ASSERT_STREQ("dummy", id);
 
-	int version = data["version"];
-	ASSERT_EQ(1, version);
+  const char* blockId = data["blockId"];
+  ASSERT_STREQ("dummy", blockId);
+
+	int type = data["type"];
+	ASSERT_EQ(0, type);
 
 	const char* sender = data["sender"];
-	ASSERT_STREQ("DMdq8j6uzxErZxESGu7JfkaCFt3qx11fqj", sender);
+	ASSERT_STREQ("dummy", sender);
 
 	const char* recipient = data["recipient"];
-	ASSERT_STREQ("DMdq8j6uzxErZxESGu7JfkaCFt3qx11fqj", recipient);
+	ASSERT_STREQ("dummy", recipient);
 
 	const char* signature = data["signature"];
-	ASSERT_STREQ("3044022073337aefa7727cc1cf39e478ffe65cf5c66c5761b5848418d87307df250a68a5022053d4d5264b329e63cadad84fc6ec479fe5e430eaabd6177db1e9c283027ec2fa", signature);
+	ASSERT_STREQ("dummy", signature);
 }
-#endif

--- a/test/api/transactions.cpp
+++ b/test/api/transactions.cpp
@@ -283,8 +283,8 @@ TEST(api, test_transaction_unconfirmed)
     uint64_t epoch = timestamp["epoch"];
     ASSERT_TRUE(40505460ull == epoch);
 
-    uint64_t unix = timestamp["unix"];
-    ASSERT_TRUE(1530606660ull == unix);
+    uint64_t unix_timestamp = timestamp["unix"];
+    ASSERT_TRUE(1530606660ull == unix_timestamp);
 
     const char* human = timestamp["human"];
     ASSERT_STREQ("2018-07-03T08:31:00Z", human);

--- a/test/api/transactions.cpp
+++ b/test/api/transactions.cpp
@@ -1,9 +1,15 @@
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "mocks/mock_api.h"
+
 #include "arkClient.h"
 #include "utils/json.h"
 
-/* test_transactions_transaction
+using testing::Return;
+
+/* test_two_transactions_transaction
  * https://dexplorer.ark.io:8443/api/v2/transactions/b324cea5c5a6c15e6ced3ec9c3135a8022eeadb8169f7ba66c80ebc82b0ac850
  * Expected Response:
     {
@@ -32,12 +38,35 @@
  */
 TEST(api, test_transaction)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto transaction = connection.api.transactions.get("b324cea5c5a6c15e6ced3ec9c3135a8022eeadb8169f7ba66c80ebc82b0ac850");
+    const std::string response = R"({
+        "data": {
+            "id": "5c6ce775447a5acd22050d72e2615392494953bb1fb6287e9ffb3c33eaeb79aa",
+            "blockId": "4271682877946294396",
+            "type": 0,
+            "amount": 32106400000,
+            "fee": 10000000,
+            "sender": "DDiTHZ4RETZhGxcyAi1VruCXZKxBFqXMeh",
+            "recipient": "DQnQNoJuNCvpjYhxL7fsnGepHBqrumgsyP",
+            "signature": "3044022047c39f6f45a46a87f91ca867f9551dbebf0035adcfcbdc1370222c7a1517fc0002206fb5ecc10460e0352a8b626a508e2fcc76e39e490b0a2581dd772ebc8079696e",
+            "confirmations": 1928,
+            "timestamp": {
+                "epoch": 32794053,
+                "unix": 1522895253,
+                "human": "2018-04-05T02:27:33Z"
+            }
+        }
+    })";
+
+    EXPECT_CALL(connection.api.transactions, get("5c6ce775447a5acd22050d72e2615392494953bb1fb6287e9ffb3c33eaeb79aa"))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto transaction = connection.api.transactions.get("5c6ce775447a5acd22050d72e2615392494953bb1fb6287e9ffb3c33eaeb79aa");
 
     DynamicJsonBuffer jsonBuffer(transaction.size());
     JsonObject& root = jsonBuffer.parseObject(transaction);
@@ -103,10 +132,28 @@ TEST(api, test_transaction)
  */
 TEST(api, test_transaction_types)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+			  "data": {
+			    "TRANSFER": 0,
+			    "SECOND_SIGNATURE": 1,
+			    "DELEGATE_REGISTRATION": 2,
+			    "VOTE": 3,
+			    "MULTI_SIGNATURE": 4,
+			    "IPFS": 5,
+			    "TIMELOCK_TRANSFER": 6,
+			    "MULTI_PAYMENT": 7,
+			    "DELEGATE_RESIGNATION": 8
+			  }
+			})";
+
+    EXPECT_CALL(connection.api.transactions, types())
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto types = connection.api.transactions.types();
 
@@ -164,12 +211,36 @@ TEST(api, test_transaction_types)
  */
 TEST(api, test_transaction_unconfirmed)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto transactionUnconfirmed = connection.api.transactions.getUnconfirmed("4bbc5433e5a4e439369f1f57825e92d07cf9cb8e07aada69c122a2125e4b9d48");
+    const std::string response = R"({
+			  "data": {
+			    "id": "dummy",
+			    "blockId": "dummy",
+			    "type": 0,
+			    "amount": 10000000,
+			    "fee": 10000000,
+			    "sender": "dummy",
+			    "recipient": "dummy",
+			    "signature": "dummy",
+			    "vendorField": "dummy",
+			    "confirmations": 10,
+			    "timestamp": {
+			      "epoch": 40505460,
+			      "unix": 1530606660,
+			      "human": "2018-07-03T08:31:00Z"
+			    }
+			  }
+			})";
+
+    EXPECT_CALL(connection.api.transactions, getUnconfirmed("dummy"))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto transactionUnconfirmed = connection.api.transactions.getUnconfirmed("dummy");
 
     DynamicJsonBuffer jsonBuffer(transactionUnconfirmed.size());
     JsonObject& root = jsonBuffer.parseObject(transactionUnconfirmed);
@@ -224,10 +295,45 @@ TEST(api, test_transaction_unconfirmed)
 #if 0
 TEST(api, test_transactions)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+      "meta": {
+          "count": 2,
+          "pageCount": 127430,
+          "totalCount": 254860,
+          "next": "/v2/transactions?page=2",
+          "previous": null,
+          "self": "/v2/transactions?page=1",
+          "first": "/v2/transactions?page=1",
+          "last": "/v2/transactions?page=127430"
+      },
+      "data": [
+          {
+              "id": "5c6ce775447a5acd22050d72e2615392494953bb1fb6287e9ffb3c33eaeb79aa",
+              "blockId": "4271682877946294396",
+              "type": 0,
+              "amount": 32106400000,
+              "fee": 10000000,
+              "sender": "DDiTHZ4RETZhGxcyAi1VruCXZKxBFqXMeh",
+              "recipient": "DQnQNoJuNCvpjYhxL7fsnGepHBqrumgsyP",
+              "signature": "3044022047c39f6f45a46a87f91ca867f9551dbebf0035adcfcbdc1370222c7a1517fc0002206fb5ecc10460e0352a8b626a508e2fcc76e39e490b0a2581dd772ebc8079696e",
+              "confirmations": 1924,
+              "timestamp": {
+                  "epoch": 32794053,
+                  "unix": 1522895253,
+                  "human": "2018-04-05T02:27:33Z"
+              }
+          }
+      ]
+  })";
+
+    EXPECT_CALL(connection.api.transactions, all(2, 1)
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto transactions = connection.api.transactions.all(2, 1);
 
@@ -277,10 +383,46 @@ TEST(api, test_transactions)
  */
 TEST(api, test_transactions_unconfirmed)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+      "meta": {
+	      "count": 1,
+	      "pageCount": 1,
+	      "totalCount": 1,
+	      "next": null,
+	      "previous": null,
+	      "self": "/api/transactions/unconfirmed?page=1&limit=1",
+	      "first": "/api/transactions/unconfirmed?page=1&limit=1",
+	      "last": "/api/transactions/unconfirmed?page=1&limit=1"
+      },
+      "data": [
+	      {
+		      "id": "dummy",
+		      "blockId": "dummy",
+		      "type": 0,
+		      "amount": 10000000,
+		      "fee": 10000000,
+		      "sender": "dummy",
+		      "recipient": "dummy",
+		      "signature": "dummy",
+		      "vendorField": "dummy",
+		      "confirmations": 10,
+		      "timestamp": {
+			      "epoch": 40505460,
+			      "unix": 1530606660,
+			      "human": "2018-07-03T08:31:00Z"
+		      }
+	      }
+      ]
+      })";
+
+    EXPECT_CALL(connection.api.transactions, allUnconfirmed(5, 1))
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto transactionsUnconfirmed = connection.api.transactions.allUnconfirmed(5, 1);
 
@@ -328,6 +470,7 @@ TEST(api, test_two_transactions_search_all)
   ASSERT_TRUE(totalCount >= 0);
 }
 
+#if 0 // TODO
 /* test_two_transactions_transactions_search
  * 
  * Expected Response:
@@ -364,44 +507,80 @@ TEST(api, test_two_transactions_search_all)
  */
 TEST(api, test_transactions_search)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const std::map<std::string, std::string> body = {
-      {"id", "927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37"}
-    };
-    const auto transactions = connection.api.transactions.search(body, 5, 1);
+    const std::string response = R"({
+			  "meta": {
+			    "count": 1,
+			    "pageCount": 1,
+			    "totalCount": 1,
+			    "next": null,
+			    "previous": null,
+			    "self": "/api/transactions/search?page=1&limit=1",
+			    "first": "/api/transactions/search?page=1&limit=1",
+			    "last": "/api/transactions/search?page=1&limit=1"
+			  },
+			  "data": [
+			    {
+			      "id": "dummy",
+			      "blockId": "dummy",
+			      "type": 0,
+			      "amount": 10000000,
+			      "fee": 10000000,
+			      "sender": "dummy",
+			      "recipient": "dummy",
+			      "signature": "dummy",
+			      "vendorField": "dummy",
+			      "confirmations": 10,
+			      "timestamp": {
+			        "epoch": 40505460,
+			        "unix": 1530606660,
+			        "human": "2018-07-03T08:31:00Z"
+			      }
+			    }
+			  ]
+			})";
 
-    DynamicJsonBuffer jsonBuffer(transactions.size());
-    JsonObject& root = jsonBuffer.parseObject(transactions);
+    EXPECT_CALL(connection.api.transactions, search(5, 1))
+      .Times(1)
+      .WillOnce(Return(response));
+	const std::map<std::string, std::string> body = {
+	  {"id", "927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37"}
+	};
+	const auto transactions = connection.api.transactions.search(body, 5, 1);
 
-    JsonObject& meta = root["meta"];
+	DynamicJsonBuffer jsonBuffer(transactions.size());
+	JsonObject& root = jsonBuffer.parseObject(transactions);
 
-    int count = meta["count"];
-    ASSERT_TRUE(count >= 0);
+	JsonObject& meta = root["meta"];
 
-    int pageCount = meta["pageCount"];
-    ASSERT_TRUE(pageCount >= 0);
+	int count = meta["count"];
+	ASSERT_TRUE(count >= 0);
 
-    int totalCount = meta["totalCount"];
-    ASSERT_TRUE(totalCount >= 0);
+	int pageCount = meta["pageCount"];
+	ASSERT_TRUE(pageCount >= 0);
 
-    JsonObject& data = root["data"][0];
+	int totalCount = meta["totalCount"];
+	ASSERT_TRUE(totalCount >= 0);
 
-    const char* id = data["id"];
-    ASSERT_STREQ("927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37", id);
+	JsonObject& data = root["data"][0];
 
-    int version = data["version"];
-    ASSERT_EQ(1, version);
+	const char* id = data["id"];
+	ASSERT_STREQ("927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37", id);
 
-    const char* sender = data["sender"];
-    ASSERT_STREQ("DMdq8j6uzxErZxESGu7JfkaCFt3qx11fqj", sender);
+	int version = data["version"];
+	ASSERT_EQ(1, version);
 
-    const char* recipient = data["recipient"];
-    ASSERT_STREQ("DMdq8j6uzxErZxESGu7JfkaCFt3qx11fqj", recipient);
+	const char* sender = data["sender"];
+	ASSERT_STREQ("DMdq8j6uzxErZxESGu7JfkaCFt3qx11fqj", sender);
 
-    const char* signature = data["signature"];
-    ASSERT_STREQ("3044022073337aefa7727cc1cf39e478ffe65cf5c66c5761b5848418d87307df250a68a5022053d4d5264b329e63cadad84fc6ec479fe5e430eaabd6177db1e9c283027ec2fa", signature);
+	const char* recipient = data["recipient"];
+	ASSERT_STREQ("DMdq8j6uzxErZxESGu7JfkaCFt3qx11fqj", recipient);
+
+	const char* signature = data["signature"];
+	ASSERT_STREQ("3044022073337aefa7727cc1cf39e478ffe65cf5c66c5761b5848418d87307df250a68a5022053d4d5264b329e63cadad84fc6ec479fe5e430eaabd6177db1e9c283027ec2fa", signature);
 }
+#endif

--- a/test/api/transactions.cpp
+++ b/test/api/transactions.cpp
@@ -547,10 +547,12 @@ TEST(api, test_transactions_search)
     EXPECT_CALL(connection.api.transactions, search(5, 1))
       .Times(1)
       .WillOnce(Return(response));
-	const std::map<std::string, std::string> body = {
-	  {"id", "927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37"}
-	};
-	const auto transactions = connection.api.transactions.search(body, 5, 1);
+
+    const auto transactions = connection.api.transactions.get("4bbc5433e5a4e439369f1f57825e92d07cf9cb8e07aada69c122a2125e4b9d48", 5, 1);
+    const std::map<std::string, std::string> body = {
+      {"id", "927ab6da141cc4fa9f1a4b5765ee9ecdf92d47a9cd3aada35aa136ad7d3d3e37"}
+    };
+    const auto transactions = connection.api.transactions.search(body, 5, 1);
 
 	DynamicJsonBuffer jsonBuffer(transactions.size());
 	JsonObject& root = jsonBuffer.parseObject(transactions);

--- a/test/api/votes.cpp
+++ b/test/api/votes.cpp
@@ -7,6 +7,7 @@
 #include "utils/json.h"
 
 using testing::Return;
+using testing::_;
 
 /* test_two_vote
  * https://dexplorer.ark.io:8443/api/v2/votes/d202acbfa947acac53ada2ac8a0eb662c9f75421ede3b10a42759352968b4ed2
@@ -66,7 +67,7 @@ TEST(api, test_vote)
         }
     })";
 
-    EXPECT_CALL(connection.api.votes, get("beb8dd43c640f562704090159154b2742afba7eacada9e8edee447e34e7675c6"))
+    EXPECT_CALL(connection.api.votes, get(_))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -78,42 +79,42 @@ TEST(api, test_vote)
     JsonObject& data = root["data"];
 
     const char* id = data["id"];
-    ASSERT_STREQ("d202acbfa947acac53ada2ac8a0eb662c9f75421ede3b10a42759352968b4ed2", id);
+    ASSERT_STREQ("beb8dd43c640f562704090159154b2742afba7eacada9e8edee447e34e7675c6", id);
 
     const char* blockId = data["blockId"];
-    ASSERT_STREQ("8320994199422256846", blockId);
+    ASSERT_STREQ("13661015019049808045", blockId);
 
     int type = data["type"];
     ASSERT_EQ(3, type);
 
     uint64_t amount = data["amount"];
-    ASSERT_TRUE(amount >= 0);
+    ASSERT_TRUE(amount == 0);
 
     uint64_t fee = data["fee"];
     ASSERT_TRUE(fee == 100000000);
 
     const char* sender = data["sender"];
-    ASSERT_STREQ("DP8CKM9bSb2crRZyaxLxjaK1mdrtuDuGJr", sender);
+    ASSERT_STREQ("DAp7JjULVgqzd4jLofkUyLRovHRPUTQwiZ", sender);
 
     const char* recipient = data["recipient"];
-    ASSERT_STREQ("DP8CKM9bSb2crRZyaxLxjaK1mdrtuDuGJr", recipient);
+    ASSERT_STREQ("DAp7JjULVgqzd4jLofkUyLRovHRPUTQwiZ", recipient);
 
     const char* signature = data["signature"];
-    ASSERT_STREQ("304402202fda01999d02d2d099a5e5e199cc6a24ca32b1e644ec855d1b9004b5068b45450220653c65a9bf48742104671e69a597b86517160f6ff87a92b89b62c290b312493c", signature);
+    ASSERT_STREQ("3045022100e9a743c5aa0df427f49af61d35fe617182479f7e8d368ce23b7ec43ab6d269c80220193aafd4ccb3eedbd76ded7ea99f31629013dc3af60540029fe98b274d42d284", signature);
 
     int confirmations = data["confirmations"];
-    ASSERT_GT(confirmations, 0);
+    ASSERT_EQ(48189, confirmations);
 
     JsonObject& timestamp = data["timestamp"];
 
     int epoch = timestamp["epoch"];
-    ASSERT_EQ(45024867, epoch);
+    ASSERT_EQ(32338609, epoch);
 
     int timestampUnix = timestamp["unix"];
-    ASSERT_EQ(1535126067, timestampUnix);
+    ASSERT_EQ(1522439809, timestampUnix);
 
     const char* human = timestamp["human"];
-    ASSERT_STREQ("2018-08-24T15:54:27.000Z", human);
+    ASSERT_STREQ("2018-03-30T19:56:49Z", human);
 }
 
 /* test_votes
@@ -198,7 +199,7 @@ TEST(api, test_votes)
         ]
     })";
 
-    EXPECT_CALL(connection.api.votes, all(5, 1))
+    EXPECT_CALL(connection.api.votes, all(_, _))
       .Times(1)
       .WillOnce(Return(response));
 

--- a/test/api/votes.cpp
+++ b/test/api/votes.cpp
@@ -1,9 +1,14 @@
-
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "mocks/mock_api.h"
+
 #include "arkClient.h"
 #include "utils/json.h"
 
-/* test_vote
+using testing::Return;
+
+/* test_two_vote
  * https://dexplorer.ark.io:8443/api/v2/votes/d202acbfa947acac53ada2ac8a0eb662c9f75421ede3b10a42759352968b4ed2
  * Expected Response:
     {
@@ -32,12 +37,40 @@
  */
 TEST(api, test_vote)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto vote = connection.api.votes.get("d202acbfa947acac53ada2ac8a0eb662c9f75421ede3b10a42759352968b4ed2");
+    const std::string response = R"({
+        "data": {
+            "id": "beb8dd43c640f562704090159154b2742afba7eacada9e8edee447e34e7675c6",
+            "blockId": "13661015019049808045",
+            "type": 3,
+            "amount": 0,
+            "fee": 100000000,
+            "sender": "DAp7JjULVgqzd4jLofkUyLRovHRPUTQwiZ",
+            "recipient": "DAp7JjULVgqzd4jLofkUyLRovHRPUTQwiZ",
+            "signature": "3045022100e9a743c5aa0df427f49af61d35fe617182479f7e8d368ce23b7ec43ab6d269c80220193aafd4ccb3eedbd76ded7ea99f31629013dc3af60540029fe98b274d42d284",
+            "asset": {
+                "votes": [
+                    "+032fe001dff675a6edfe3d0e51201b2900d3b5050a46d770306aefaa574c022672"
+                ]
+            },
+            "confirmations": 48189,
+            "timestamp": {
+                "epoch": 32338609,
+                "unix": 1522439809,
+                "human": "2018-03-30T19:56:49Z"
+            }
+        }
+    })";
+
+    EXPECT_CALL(connection.api.votes, get("beb8dd43c640f562704090159154b2742afba7eacada9e8edee447e34e7675c6"))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto vote = connection.api.votes.get("beb8dd43c640f562704090159154b2742afba7eacada9e8edee447e34e7675c6");
 
     DynamicJsonBuffer jsonBuffer(vote.size());
     JsonObject& root = jsonBuffer.parseObject(vote);
@@ -124,15 +157,55 @@ TEST(api, test_vote)
  */
 TEST(api, test_votes)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto transactionUnconfirmed = connection.api.votes.all(5, 1);
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 658,
+            "totalCount": 1315,
+            "next": "/v2/votes?page=2",
+            "previous": null,
+            "self": "/v2/votes?page=1",
+            "first": "/v2/votes?page=1",
+            "last": "/v2/votes?page=658"
+        },
+        "data": [
+            {
+                "id": "560959e435cbf8eec60691890f3dd55d141e76077e1fe803f65d137c91099240",
+                "blockId": "12872155462883631430",
+                "type": 3,
+                "amount": 0,
+                "fee": 100000000,
+                "sender": "DAp7JjULVgqzd4jLofkUyLRovHRPUTQwiZ",
+                "recipient": "DAp7JjULVgqzd4jLofkUyLRovHRPUTQwiZ",
+                "signature": "30440220522eadff84b5b4b2fc6a3ef611bf093dbd0a06963c32c767ee28729898d0a1d302203f851594e5b2271a987e98daa4fc8b5f384fac65c41eb1c43739af2d4b5dc902",
+                "asset": {
+                    "votes": [
+                        "-032fe001dff675a6edfe3d0e51201b2900d3b5050a46d770306aefaa574c022672"
+                    ]
+                },
+                "confirmations": 39989,
+                "timestamp": {
+                    "epoch": 32414926,
+                    "unix": 1522516126,
+                    "human": "2018-03-31T17:08:46Z"
+                }
+            }
+        ]
+    })";
 
-    DynamicJsonBuffer jsonBuffer(transactionUnconfirmed.size());
-    JsonObject& root = jsonBuffer.parseObject(transactionUnconfirmed);
+    EXPECT_CALL(connection.api.votes, all(5, 1))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto votes = connection.api.votes.all(5, 1);
+
+    DynamicJsonBuffer jsonBuffer(votes.size());
+    JsonObject& root = jsonBuffer.parseObject(votes);
 
     JsonObject& meta = root["meta"];
 

--- a/test/api/wallets.cpp
+++ b/test/api/wallets.cpp
@@ -7,6 +7,7 @@
 #include "utils/json.h"
 
 using testing::Return;
+using testing::_;
 
 /* test_two_vote_identifier
  * https://dexplorer.ark.io:8443/api/v2/wallets/DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu
@@ -218,18 +219,17 @@ TEST(api, test_wallets_search)
         ]
     })";
 
-    
-    EXPECT_CALL(connection.api.wallets, search(std::make_pair("address", "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN"), 5, 1))
+    const std::map<std::string, std::string> body_parameters = {
+     {"username", "baldninja"},
+     {"address", "DFJ5Z51F1euNNdRUQJKQVdG4h495LZkc6T"},
+     {"publicKey", "03d3c6889608074b44155ad2e6577c3368e27e6e129c457418eb3e5ed029544e8d"}
+    };
+
+    EXPECT_CALL(connection.api.wallets, search(_, _, _))
       .Times(1)
       .WillOnce(Return(response));
-
-	const std::map<std::string, std::string> body_parameters = {
-	  {"username", "baldninja"},
-	  {"address", "DFJ5Z51F1euNNdRUQJKQVdG4h495LZkc6T"},
-	  {"publicKey", "03d3c6889608074b44155ad2e6577c3368e27e6e129c457418eb3e5ed029544e8d"}
-	};
-
-    const auto walletsSearch = connection.api.wallets.search(body_parameters);
+   
+    const auto walletsSearch = connection.api.wallets.search(body_parameters, 5, 1);
 
     DynamicJsonBuffer jsonBuffer(walletsSearch.size());
     JsonObject& root = jsonBuffer.parseObject(walletsSearch);

--- a/test/api/wallets.cpp
+++ b/test/api/wallets.cpp
@@ -1,9 +1,14 @@
-
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "mocks/mock_api.h"
+
 #include "arkClient.h"
 #include "utils/json.h"
 
-/* test_vote_identifier
+using testing::Return;
+
+/* test_two_vote_identifier
  * https://dexplorer.ark.io:8443/api/v2/wallets/DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu
  * Expected Response:
     {
@@ -18,12 +23,25 @@
  */
 TEST(api, test_wallet)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto wallet = connection.api.wallets.get("DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu");
+    const std::string response = R"({
+        "data": {
+            "address": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+            "publicKey": "022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d",
+            "balance": 12534670000000,
+            "isDelegate": true
+        }
+    })";
+
+    EXPECT_CALL(connection.api.wallets, get("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN"))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto wallet = connection.api.wallets.get("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN");
 
     DynamicJsonBuffer jsonBuffer(wallet.size());
     JsonObject& root = jsonBuffer.parseObject(wallet);
@@ -70,10 +88,35 @@ TEST(api, test_wallet)
  */
 TEST(api, test_wallets)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 421,
+            "totalCount": 841,
+            "next": "/v2/wallets?page=2",
+            "previous": null,
+            "self": "/v2/wallets?page=1",
+            "first": "/v2/wallets?page=1",
+            "last": "/v2/wallets?page=421"
+        },
+        "data": [
+            {
+                "address": "D59NTfV92ca9QevUydvMiFMFdubbCaAVCV",
+                "publicKey": "037d035f08b3bad0d5bb605232c7aa41555693c480044dbeb797270a44c339da5a",
+                "balance": 1023145260990,
+                "isDelegate": false
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.wallets, all(5, 1))
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto wallets = connection.api.wallets.all(5, 1);
 
@@ -134,16 +177,57 @@ TEST(api, test_wallets)
  */
 TEST(api, test_wallets_search)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const std::map<std::string, std::string> body_parameters = {
-      {"username", "baldninja"},
-      {"address", "DFJ5Z51F1euNNdRUQJKQVdG4h495LZkc6T"},
-      {"publicKey", "03d3c6889608074b44155ad2e6577c3368e27e6e129c457418eb3e5ed029544e8d"}
-    };
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 2,
+            "totalCount": 3,
+            "next": "/v2/wallets/search?page=2",
+            "previous": null,
+            "self": "/v2/wallets/search?page=1",
+            "first": "/v2/wallets/search?page=1",
+            "last": "/v2/wallets/search?page=2"
+        },
+        "data": [
+            {
+                "id": "08c6b23f9edd97b613f17153fb97a316a4fb83136e9842655dafc8262f363e0e",
+                "blockId": "14847399772737279404",
+                "type": 3,
+                "amount": 0,
+                "fee": 100000000,
+                "sender": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                "recipient": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                "signature": "304402207ba0e8aaee93695360081b7ce713f13d62b544038ac440bd46357398af86cae6022059ac74586738be1ef622e0baba992d0e417d9aed7ab980f374eb0c9d53e25f8e",
+                "asset": {
+                    "votes": [
+                        "+0257b7724e97cd832e0c28533a86da5220656f9b5122141daab20e8526decce01f"
+                    ]
+                },
+                "confirmations": 1636029,
+                "timestamp": {
+                    "epoch": 17094358,
+                    "unix": 1507195558,
+                    "human": "2017-10-05T09:25:58Z"
+                }
+            }
+        ]
+    })";
+
+    
+    EXPECT_CALL(connection.api.wallets, search(std::make_pair("address", "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN"), 5, 1))
+      .Times(1)
+      .WillOnce(Return(response));
+
+	const std::map<std::string, std::string> body_parameters = {
+	  {"username", "baldninja"},
+	  {"address", "DFJ5Z51F1euNNdRUQJKQVdG4h495LZkc6T"},
+	  {"publicKey", "03d3c6889608074b44155ad2e6577c3368e27e6e129c457418eb3e5ed029544e8d"}
+	};
 
     const auto walletsSearch = connection.api.wallets.search(body_parameters);
 
@@ -198,10 +282,32 @@ TEST(api, test_wallets_search)
  */
 TEST(api, test_wallets_top)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
+
+    const std::string response = R"({
+        "data": [
+            {
+                "address": "DGihocTkwDygiFvmg6aG8jThYTic47GzU9",
+                "publicKey": "024c8247388a02ecd1de2a3e3fd5b7c61ecc2797fa3776599d558333ef1802d231",
+                "balance": 11499593462120632,
+                "isDelegate": false
+            },
+            {
+                "address": "DRac35wghMcmUSe5jDMLBDLWkVVjyKZFxK",
+                "publicKey": "0374e9a97611540a9ce4812b0980e62d3c5141ea964c2cab051f14a78284570dcd",
+                "balance": 554107676293547,
+                "isDelegate": false
+            },
+            ...
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.wallets, top(5, 1))
+      .Times(1)
+      .WillOnce(Return(response));
 
     const auto walletsTop = connection.api.wallets.top(5, 1);
 
@@ -269,12 +375,47 @@ TEST(api, test_wallets_top)
  */
 TEST(api, test_wallets_transactions)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto walletsTransactions = connection.api.wallets.transactions("DNv1iScT2DJBWzpJd1AFYkTx1xkAZ9XVJk", 2, 1);
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 127430,
+            "totalCount": 254860,
+            "next": "/v2/wallets/boldninja/transactions?page=2",
+            "previous": null,
+            "self": "/v2/wallets/boldninja/transactions?page=1",
+            "first": "/v2/wallets/boldninja/transactions?page=1",
+            "last": "/v2/wallets/boldninja/transactions?page=127430"
+        },
+        "data": [
+            {
+                "id": "5c6ce775447a5acd22050d72e2615392494953bb1fb6287e9ffb3c33eaeb79aa",
+                "blockId": "4271682877946294396",
+                "type": 0,
+                "amount": 32106400000,
+                "fee": 10000000,
+                "sender": "DDiTHZ4RETZhGxcyAi1VruCXZKxBFqXMeh",
+                "recipient": "DQnQNoJuNCvpjYhxL7fsnGepHBqrumgsyP",
+                "signature": "3044022047c39f6f45a46a87f91ca867f9551dbebf0035adcfcbdc1370222c7a1517fc0002206fb5ecc10460e0352a8b626a508e2fcc76e39e490b0a2581dd772ebc8079696e",
+                "confirmations": 1683,
+                "timestamp": {
+                    "epoch": 32794053,
+                    "unix": 1522895253,
+                    "human": "2018-04-05T02:27:33Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.wallets, transactions("DDiTHZ4RETZhGxcyAi1VruCXZKxBFqXMeh", 2, 1))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto walletsTransactions = connection.api.wallets.transactions("DDiTHZ4RETZhGxcyAi1VruCXZKxBFqXMeh", 2, 1);
 
     DynamicJsonBuffer jsonBuffer(walletsTransactions.size());
     JsonObject& root = jsonBuffer.parseObject(walletsTransactions);
@@ -306,12 +447,48 @@ TEST(api, test_wallets_transactions)
  */
 TEST(api, test_wallets_transactions_received)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto walletsTransactionsReceived = connection.api.wallets.transactionsReceived("DNv1iScT2DJBWzpJd1AFYkTx1xkAZ9XVJk", 2, 1);
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 4,
+            "totalCount": 8,
+            "next": "/v2/wallets/boldninja/transactions/received?page=2",
+            "previous": null,
+            "self": "/v2/wallets/boldninja/transactions/received?page=1",
+            "first": "/v2/wallets/boldninja/transactions/received?page=1",
+            "last": "/v2/wallets/boldninja/transactions/received?page=4"
+        },
+        "data": [
+            {
+                "id": "c46a6a83f7a358f269691c16f050beeab669767643634086bc12ad1182d54413",
+                "blockId": "17271524574301696572",
+                "type": 0,
+                "amount": 5000000000,
+                "fee": 10000000,
+                "sender": "DK6Q1Lufhb939H9EshLViYbaaKUkswMiUz",
+                "recipient": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                "signature": "304402204b81411e507273f2a27e6135510abda5bff00a0d3121977df09363227c8fd2360220503cab4484a7db785d91a7adcfad681811e3d73f2d00b4dab7e4190ecd41cb34",
+                "vendorField": "More monopoly money for EVERYONE!!",
+                "confirmations": 1482069,
+                "timestamp": {
+                    "epoch": 18382414,
+                    "unix": 1508483614,
+                    "human": "2017-10-20T07:13:34Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.wallets, transactionsReceived("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 2, 1))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto walletsTransactionsReceived = connection.api.wallets.transactionsReceived("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 2, 1);
 
     DynamicJsonBuffer jsonBuffer(walletsTransactionsReceived.size());
     JsonObject& root = jsonBuffer.parseObject(walletsTransactionsReceived);
@@ -349,12 +526,52 @@ TEST(api, test_wallets_transactions_received)
  */
 TEST(api, test_wallets_transactions_sent)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
  
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto walletsTransactionsSent = connection.api.wallets.transactionsSent("DNv1iScT2DJBWzpJd1AFYkTx1xkAZ9XVJk", 2, 1);
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 2,
+            "totalCount": 4,
+            "next": "/v2/wallets/boldninja/transactions/sent?page=2",
+            "previous": null,
+            "self": "/v2/wallets/boldninja/transactions/sent?page=1",
+            "first": "/v2/wallets/boldninja/transactions/sent?page=1",
+            "last": "/v2/wallets/boldninja/transactions/sent?page=2"
+        },
+        "data": [
+            {
+                "id": "08c6b23f9edd97b613f17153fb97a316a4fb83136e9842655dafc8262f363e0e",
+                "blockId": "14847399772737279404",
+                "type": 3,
+                "amount": 0,
+                "fee": 100000000,
+                "sender": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                "recipient": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                "signature": "304402207ba0e8aaee93695360081b7ce713f13d62b544038ac440bd46357398af86cae6022059ac74586738be1ef622e0baba992d0e417d9aed7ab980f374eb0c9d53e25f8e",
+                "asset": {
+                    "votes": [
+                        "+0257b7724e97cd832e0c28533a86da5220656f9b5122141daab20e8526decce01f"
+                    ]
+                },
+                "confirmations": 1636232,
+                "timestamp": {
+                    "epoch": 17094358,
+                    "unix": 1507195558,
+                    "human": "2017-10-05T09:25:58Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.wallets, transactionsSent("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 2, 1))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto walletsTransactionsSent = connection.api.wallets.transactionsSent("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 2, 1);
 
     DynamicJsonBuffer jsonBuffer(walletsTransactionsSent.size());
     JsonObject& root = jsonBuffer.parseObject(walletsTransactionsSent);
@@ -412,12 +629,52 @@ TEST(api, test_wallets_transactions_sent)
  */
 TEST(api, test_wallets_votes)
 {
-    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();
     ASSERT_EQ(2, apiVersion);
 
-    const auto walletsVotes = connection.api.wallets.votes("DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", 1, 1);
+    const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 2,
+            "totalCount": 3,
+            "next": "/v2/wallets/boldninja/votes?page=2",
+            "previous": null,
+            "self": "/v2/wallets/boldninja/votes?page=1",
+            "first": "/v2/wallets/boldninja/votes?page=1",
+            "last": "/v2/wallets/boldninja/votes?page=2"
+        },
+        "data": [
+            {
+                "id": "08c6b23f9edd97b613f17153fb97a316a4fb83136e9842655dafc8262f363e0e",
+                "blockId": "14847399772737279404",
+                "type": 3,
+                "amount": 0,
+                "fee": 100000000,
+                "sender": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                "recipient": "DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN",
+                "signature": "304402207ba0e8aaee93695360081b7ce713f13d62b544038ac440bd46357398af86cae6022059ac74586738be1ef622e0baba992d0e417d9aed7ab980f374eb0c9d53e25f8e",
+                "asset": {
+                    "votes": [
+                        "+0257b7724e97cd832e0c28533a86da5220656f9b5122141daab20e8526decce01f"
+                    ]
+                },
+                "confirmations": 1636029,
+                "timestamp": {
+                    "epoch": 17094358,
+                    "unix": 1507195558,
+                    "human": "2017-10-05T09:25:58Z"
+                }
+            }
+        ]
+    })";
+
+    EXPECT_CALL(connection.api.wallets, votes("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 1, 1))
+      .Times(1)
+      .WillOnce(Return(response));
+
+    const auto walletsVotes = connection.api.wallets.votes("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 1, 1);
 
     DynamicJsonBuffer jsonBuffer(walletsVotes.size());
     JsonObject& root = jsonBuffer.parseObject(walletsVotes);

--- a/test/api/wallets.cpp
+++ b/test/api/wallets.cpp
@@ -38,7 +38,7 @@ TEST(api, test_wallet)
         }
     })";
 
-    EXPECT_CALL(connection.api.wallets, get("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN"))
+    EXPECT_CALL(connection.api.wallets, get(_))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -50,16 +50,16 @@ TEST(api, test_wallet)
     JsonObject& data = root["data"];
 
     const char* address = data["address"];
-    ASSERT_STREQ("DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu", address);
+    ASSERT_STREQ("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", address);
 
     const char* publicKey = data["publicKey"];
-    ASSERT_STREQ("023ee98f453661a1cb765fd60df95b4efb1e110660ffb88ae31c2368a70f1f7359", publicKey);
+    ASSERT_STREQ("022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d", publicKey);
 
     uint64_t balance = data["balance"];
-    ASSERT_TRUE(balance >= 0);
+    ASSERT_TRUE(balance == 12534670000000);
 
     bool isDelegate = data["isDelegate"];
-    ASSERT_TRUE((isDelegate == true || isDelegate == false) == true);
+    ASSERT_TRUE(isDelegate);
 }
 
 /* test_wallets
@@ -115,7 +115,7 @@ TEST(api, test_wallets)
         ]
     })";
 
-    EXPECT_CALL(connection.api.wallets, all(5, 1))
+    EXPECT_CALL(connection.api.wallets, all(_, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -139,16 +139,16 @@ TEST(api, test_wallets)
     JsonObject& dataZero = root["data"][0];
 
     const char* address = dataZero["address"];
-    ASSERT_STRNE("", address);
+    ASSERT_STREQ("D59NTfV92ca9QevUydvMiFMFdubbCaAVCV", address);
 
     const char* publicKey = dataZero["publicKey"];
-    ASSERT_STRNE("", publicKey);
+    ASSERT_STREQ("037d035f08b3bad0d5bb605232c7aa41555693c480044dbeb797270a44c339da5a", publicKey);
 
     uint64_t balance = dataZero["balance"];
     ASSERT_TRUE(balance >= 0);
 
     bool isDelegate = dataZero["isDelegate"];
-    ASSERT_TRUE((isDelegate == true || isDelegate == false) == true);
+    ASSERT_FALSE(isDelegate);
 }
 
 /* test_wallets_search
@@ -248,11 +248,43 @@ TEST(api, test_wallets_search)
 
     JsonObject& dataZero = root["data"][0];;
 
-    const char* address = dataZero["address"];
-    ASSERT_STRNE("", address);
+    const char* id = dataZero["id"];
+    ASSERT_STREQ("08c6b23f9edd97b613f17153fb97a316a4fb83136e9842655dafc8262f363e0e", id);
 
-    const char* publicKey = dataZero["publicKey"];
-    ASSERT_STRNE("", publicKey);
+    const char* blockId = dataZero["blockId"];
+    ASSERT_STREQ("14847399772737279404", blockId);
+
+    int type = dataZero["type"];
+    ASSERT_EQ(3, type);
+
+    uint64_t amount = dataZero["amount"];
+    ASSERT_TRUE(0ull == amount);
+
+    uint64_t fee = dataZero["fee"];
+    ASSERT_TRUE(100000000ull == fee);
+
+    const char* sender = dataZero["sender"];
+    ASSERT_STREQ("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", sender);
+
+    const char* recipient = dataZero["recipient"];
+    ASSERT_STREQ("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", recipient);
+
+    const char* signature = dataZero["signature"];
+    ASSERT_STREQ("304402207ba0e8aaee93695360081b7ce713f13d62b544038ac440bd46357398af86cae6022059ac74586738be1ef622e0baba992d0e417d9aed7ab980f374eb0c9d53e25f8e", signature);
+
+    int confirmations = dataZero["confirmations"];
+    ASSERT_EQ(1636029, confirmations);
+
+    JsonObject& timestamp = dataZero["timestamp"];
+
+    int epoch = timestamp["epoch"];
+    ASSERT_EQ(17094358, epoch);
+
+    int timestampUnix = timestamp["unix"];
+    ASSERT_EQ(1507195558, timestampUnix);
+
+    const char* human = timestamp["human"];
+    ASSERT_STREQ("2017-10-05T09:25:58Z", human);
 }
 
 /* test_wallets_top_limit_page
@@ -288,6 +320,16 @@ TEST(api, test_wallets_top)
     ASSERT_EQ(2, apiVersion);
 
     const std::string response = R"({
+        "meta": {
+            "count": 2,
+            "pageCount": 1,
+            "totalCount": 2,
+            "next": "/api/v2/wallets/top?limit=5&page=1",
+            "previous": null,
+            "self": "/api/v2/wallets/top?limit=5&page=1",
+            "first": "/api/v2/wallets/top?limit=5&page=1",
+            "last": "/api/v2/wallets/top?limit=5&page=1"
+        },
         "data": [
             {
                 "address": "DGihocTkwDygiFvmg6aG8jThYTic47GzU9",
@@ -301,11 +343,10 @@ TEST(api, test_wallets_top)
                 "balance": 554107676293547,
                 "isDelegate": false
             },
-            ...
         ]
     })";
 
-    EXPECT_CALL(connection.api.wallets, top(5, 1))
+    EXPECT_CALL(connection.api.wallets, top(_, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -329,14 +370,30 @@ TEST(api, test_wallets_top)
     JsonObject& dataZero = root["data"][0];
 
     const char* address = dataZero["address"];
-    ASSERT_STRNE("", address);
+    ASSERT_STREQ("DGihocTkwDygiFvmg6aG8jThYTic47GzU9", address);
+
+    const char* publicKey = dataZero["publicKey"];
+    ASSERT_STREQ("024c8247388a02ecd1de2a3e3fd5b7c61ecc2797fa3776599d558333ef1802d231", publicKey);
 
     uint64_t balance = dataZero["balance"];
-    ASSERT_TRUE(balance >= 0);
+    ASSERT_TRUE(balance == 11499593462120632ull);
 
     bool isDelegate = dataZero["isDelegate"];
-    // as long as data was read, we don't really care (or know) what the expected value is
-    ASSERT_TRUE(isDelegate || !isDelegate);
+    ASSERT_FALSE(isDelegate);
+
+    JsonObject& dataOne = root["data"][1];
+
+    address = dataOne["address"];
+    ASSERT_STREQ("DRac35wghMcmUSe5jDMLBDLWkVVjyKZFxK", address);
+
+    publicKey = dataOne["publicKey"];
+    ASSERT_STREQ("0374e9a97611540a9ce4812b0980e62d3c5141ea964c2cab051f14a78284570dcd", publicKey);
+
+    balance = dataOne["balance"];
+    ASSERT_TRUE(balance == 554107676293547ull);
+
+    isDelegate = dataOne["isDelegate"];
+    ASSERT_FALSE(isDelegate);
 }
 
 /* test_wallets_transactions
@@ -411,7 +468,7 @@ TEST(api, test_wallets_transactions)
         ]
     })";
 
-    EXPECT_CALL(connection.api.wallets, transactions("DDiTHZ4RETZhGxcyAi1VruCXZKxBFqXMeh", 2, 1))
+    EXPECT_CALL(connection.api.wallets, transactions(_, _, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -423,7 +480,7 @@ TEST(api, test_wallets_transactions)
     JsonObject& meta = root["meta"];
 
     int count = meta["count"];
-    ASSERT_NE(0, count);
+    ASSERT_EQ(2, count);
 }
 
 /* test_wallets_transactions_received
@@ -484,7 +541,7 @@ TEST(api, test_wallets_transactions_received)
         ]
     })";
 
-    EXPECT_CALL(connection.api.wallets, transactionsReceived("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 2, 1))
+    EXPECT_CALL(connection.api.wallets, transactionsReceived(_, _, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -567,7 +624,7 @@ TEST(api, test_wallets_transactions_sent)
         ]
     })";
 
-    EXPECT_CALL(connection.api.wallets, transactionsSent("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 2, 1))
+    EXPECT_CALL(connection.api.wallets, transactionsSent(_, _, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -670,7 +727,7 @@ TEST(api, test_wallets_votes)
         ]
     })";
 
-    EXPECT_CALL(connection.api.wallets, votes("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", 1, 1))
+    EXPECT_CALL(connection.api.wallets, votes(_, _, _))
       .Times(1)
       .WillOnce(Return(response));
 
@@ -687,5 +744,5 @@ TEST(api, test_wallets_votes)
     JsonObject& data = root["data"][0];
 
     const char* sender = data["sender"];
-    ASSERT_STREQ("DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", sender);
+    ASSERT_STREQ("DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN", sender);
 }

--- a/test/connection/connection.cpp
+++ b/test/connection/connection.cpp
@@ -1,5 +1,7 @@
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
 #include "arkClient.h"
 
 TEST(api, test_connection)

--- a/test/mocks/mock_api.h
+++ b/test/mocks/mock_api.h
@@ -59,11 +59,11 @@ class MockTransactions : public Ark::Client::API::TWO::ITransactions
 public:
   MockTransactions(Ark::Client::IHTTP& http) : ITransactions(http) { }
 
-  MOCK_METHOD3(getUnconfirmed, std::string(const char* const, int, int));
-  MOCK_METHOD3(get, std::string(const char* const, int, int));
+  MOCK_METHOD1(getUnconfirmed, std::string(const char* const));
+  MOCK_METHOD1(get, std::string(const char* const));
   MOCK_METHOD2(all, std::string(int, int));
   MOCK_METHOD2(allUnconfirmed, std::string(int, int));
-  MOCK_METHOD2(types, std::string(int, int));
+  MOCK_METHOD0(types, std::string());
 };
 
 class MockVotes : public Ark::Client::API::TWO::IVotes

--- a/test/mocks/mock_api.h
+++ b/test/mocks/mock_api.h
@@ -1,0 +1,107 @@
+/**
+ * This file is part of Ark Cpp Client.
+ *
+ * (c) Ark Ecosystem <info@ark.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ **/
+
+#ifndef MOCK_API_H
+#define MOCK_API_H
+
+#include "arkClient.h"
+#include "http/http.h"
+#include "mocks/mock_http.h"
+
+class MockBlocks : public Ark::Client::API::TWO::IBlocks
+{
+public:
+  MockBlocks(Ark::Client::IHTTP& http) : IBlocks(http) { }
+
+  MOCK_METHOD1(get, std::string(const char* const));
+  MOCK_METHOD2(all, std::string(int, int));
+  MOCK_METHOD1(transactions, std::string(const char* const));
+  MOCK_METHOD3(search, std::string(std::pair<const char*, const char*>, int, int));
+};
+
+class MockDelegates : public Ark::Client::API::TWO::IDelegates
+{
+public:
+  MockDelegates(Ark::Client::IHTTP& http) : IDelegates(http) { }
+
+  MOCK_METHOD1(get, std::string(const char* const));
+  MOCK_METHOD2(all, std::string(int, int));
+  MOCK_METHOD3(blocks, std::string(const char* const, int, int));
+  MOCK_METHOD3(voters, std::string(const char* const, int, int));
+};
+
+class MockNode : public Ark::Client::API::TWO::INode {
+public:
+  MockNode(Ark::Client::IHTTP& http) : INode(http) { }
+
+  MOCK_METHOD0(configuration, std::string());
+  MOCK_METHOD0(status, std::string());
+  MOCK_METHOD0(syncing, std::string());
+};
+
+class MockPeers : public Ark::Client::API::TWO::IPeers
+{
+public:
+  MockPeers(Ark::Client::IHTTP& http) : IPeers(http) { }
+
+  MOCK_METHOD1(get, std::string(const char* const));
+  MOCK_METHOD2(all, std::string(int, int));
+};
+
+class MockTransactions : public Ark::Client::API::TWO::ITransactions
+{
+public:
+  MockTransactions(Ark::Client::IHTTP& http) : ITransactions(http) { }
+
+  MOCK_METHOD3(getUnconfirmed, std::string(const char* const, int, int));
+  MOCK_METHOD3(get, std::string(const char* const, int, int));
+  MOCK_METHOD2(all, std::string(int, int));
+  MOCK_METHOD2(allUnconfirmed, std::string(int, int));
+  MOCK_METHOD2(types, std::string(int, int));
+};
+
+class MockVotes : public Ark::Client::API::TWO::IVotes
+{
+public:
+  MockVotes(Ark::Client::IHTTP& http) : IVotes(http) { }
+
+  MOCK_METHOD1(get, std::string(const char* const));
+  MOCK_METHOD2(all, std::string(int, int));
+};
+
+class MockWallets : public Ark::Client::API::TWO::IWallets
+{
+public:
+  MockWallets(Ark::Client::IHTTP& http) : IWallets(http) { }
+
+  MOCK_METHOD3(get, std::string(const char* const, int, int));
+  MOCK_METHOD2(all, std::string(int, int));
+  MOCK_METHOD2(top, std::string(int, int));
+  MOCK_METHOD3(transactions, std::string(const char* const, int, int));
+  MOCK_METHOD3(transactionsReceived, std::string(const char* const, int, int));
+  MOCK_METHOD3(transactionsSent, std::string(const char* const, int, int));
+  MOCK_METHOD3(votes, std::string(const char* const, int, int));
+  MOCK_METHOD3(search, std::string(std::pair<const char*, const char*>, int, int));
+};
+
+class MockApi : public Ark::Client::AbstractApi
+{
+public:
+  MockBlocks blocks;
+  MockDelegates delegates;
+  MockNode node;
+  MockPeers peers;
+  MockTransactions transactions;
+  MockVotes votes;
+  MockWallets wallets;
+
+  MockApi() : AbstractApi(new MockHTTP(), 2), blocks(*http_), delegates(*http_), node(*http_), peers(*http_), transactions(*http_), votes(*http_), wallets(*http_) { }
+};
+
+#endif

--- a/test/mocks/mock_api.h
+++ b/test/mocks/mock_api.h
@@ -22,7 +22,7 @@ public:
   MOCK_METHOD1(get, std::string(const char* const));
   MOCK_METHOD2(all, std::string(int, int));
   MOCK_METHOD1(transactions, std::string(const char* const));
-  MOCK_METHOD3(search, std::string(std::pair<const char*, const char*>, int, int));
+  MOCK_METHOD3(search, std::string(const std::map<std::string, std::string>&, int, int));
 };
 
 class MockDelegates : public Ark::Client::API::TWO::IDelegates
@@ -64,6 +64,7 @@ public:
   MOCK_METHOD2(all, std::string(int, int));
   MOCK_METHOD2(allUnconfirmed, std::string(int, int));
   MOCK_METHOD0(types, std::string());
+  MOCK_METHOD3(search, std::string(const std::map<std::string, std::string>&, int, int));
 };
 
 class MockVotes : public Ark::Client::API::TWO::IVotes
@@ -87,10 +88,10 @@ public:
   MOCK_METHOD3(transactionsReceived, std::string(const char* const, int, int));
   MOCK_METHOD3(transactionsSent, std::string(const char* const, int, int));
   MOCK_METHOD3(votes, std::string(const char* const, int, int));
-  MOCK_METHOD3(search, std::string(std::pair<const char*, const char*>, int, int));
+  MOCK_METHOD3(search, std::string(const std::map<std::string, std::string>&, int, int));
 };
 
-class MockApi : public Ark::Client::AbstractApi
+class MockApi : public Ark::Client::API::Abstract
 {
 public:
   MockBlocks blocks;
@@ -101,7 +102,7 @@ public:
   MockVotes votes;
   MockWallets wallets;
 
-  MockApi() : AbstractApi(new MockHTTP(), 2), blocks(*http_), delegates(*http_), node(*http_), peers(*http_), transactions(*http_), votes(*http_), wallets(*http_) { }
+  MockApi() : Abstract(new MockHTTP(), 2), blocks(*http_), delegates(*http_), node(*http_), peers(*http_), transactions(*http_), votes(*http_), wallets(*http_) { }
 };
 
 #endif

--- a/test/mocks/mock_api.h
+++ b/test/mocks/mock_api.h
@@ -14,7 +14,7 @@
 #include "http/http.h"
 #include "mocks/mock_http.h"
 
-class MockBlocks : public Ark::Client::API::TWO::IBlocks
+class MockBlocks : public Ark::Client::API::IBlocks
 {
 public:
   MockBlocks(Ark::Client::IHTTP& http) : IBlocks(http) { }
@@ -25,7 +25,7 @@ public:
   MOCK_METHOD3(search, std::string(const std::map<std::string, std::string>&, int, int));
 };
 
-class MockDelegates : public Ark::Client::API::TWO::IDelegates
+class MockDelegates : public Ark::Client::API::IDelegates
 {
 public:
   MockDelegates(Ark::Client::IHTTP& http) : IDelegates(http) { }
@@ -36,7 +36,7 @@ public:
   MOCK_METHOD3(voters, std::string(const char* const, int, int));
 };
 
-class MockNode : public Ark::Client::API::TWO::INode {
+class MockNode : public Ark::Client::API::INode {
 public:
   MockNode(Ark::Client::IHTTP& http) : INode(http) { }
 
@@ -45,7 +45,7 @@ public:
   MOCK_METHOD0(syncing, std::string());
 };
 
-class MockPeers : public Ark::Client::API::TWO::IPeers
+class MockPeers : public Ark::Client::API::IPeers
 {
 public:
   MockPeers(Ark::Client::IHTTP& http) : IPeers(http) { }
@@ -54,7 +54,7 @@ public:
   MOCK_METHOD2(all, std::string(int, int));
 };
 
-class MockTransactions : public Ark::Client::API::TWO::ITransactions
+class MockTransactions : public Ark::Client::API::ITransactions
 {
 public:
   MockTransactions(Ark::Client::IHTTP& http) : ITransactions(http) { }
@@ -67,7 +67,7 @@ public:
   MOCK_METHOD3(search, std::string(const std::map<std::string, std::string>&, int, int));
 };
 
-class MockVotes : public Ark::Client::API::TWO::IVotes
+class MockVotes : public Ark::Client::API::IVotes
 {
 public:
   MockVotes(Ark::Client::IHTTP& http) : IVotes(http) { }
@@ -76,7 +76,7 @@ public:
   MOCK_METHOD2(all, std::string(int, int));
 };
 
-class MockWallets : public Ark::Client::API::TWO::IWallets
+class MockWallets : public Ark::Client::API::IWallets
 {
 public:
   MockWallets(Ark::Client::IHTTP& http) : IWallets(http) { }

--- a/test/mocks/mock_api.h
+++ b/test/mocks/mock_api.h
@@ -80,7 +80,7 @@ class MockWallets : public Ark::Client::API::TWO::IWallets
 public:
   MockWallets(Ark::Client::IHTTP& http) : IWallets(http) { }
 
-  MOCK_METHOD3(get, std::string(const char* const, int, int));
+  MOCK_METHOD1(get, std::string(const char* const));
   MOCK_METHOD2(all, std::string(int, int));
   MOCK_METHOD2(top, std::string(int, int));
   MOCK_METHOD3(transactions, std::string(const char* const, int, int));

--- a/test/mocks/mock_http.h
+++ b/test/mocks/mock_http.h
@@ -1,0 +1,20 @@
+#ifndef __MOCK_HTTP_H__
+#define __MOCK_HTTP_H__
+
+#include "http/http.h"
+
+#include "gmock/gmock.h"
+
+class MockHTTP : public Ark::Client::IHTTP {
+public:
+  MockHTTP() = default;
+  
+  MOCK_CONST_METHOD0(host, const char*());
+  MOCK_CONST_METHOD0(port, int());
+  MOCK_CONST_METHOD0(api_version, int());
+  MOCK_METHOD3(setHost, bool(const char* const, int, int));
+  MOCK_METHOD1(get, std::string(const char* const));
+  MOCK_METHOD2(post, std::string(const char* const, const char* const));
+};
+
+#endif


### PR DESCRIPTION
## Proposed changes
Convert the unit tests to use mocks (GMock) instead of querying the real network.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible..
-->
- [X] New feature (non-breaking change which adds functionality)
- [X] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [X] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## Further comments
Since we were using GTest, using GMock for the mocking framework was a natural fix since we already had the dependency.

This change just implements mocking on the desktop builds.  PlatformIO tests are disabled.

I have been working with the googletest team and have submitted several PRs to add PlatformIO support to GTest and GMock.  Once this support is fully available, the PIO builds will be converted to use GTest and GMock.

This change assumes the dropping of v1 support so as such it is targeting develop branch.

Also made couple minor, breaking interface changes to some of the API calls.  Mainly, removing options for page and limit when the server doesn't return paginated results.

This change supports #27 but does not fully close it until PIO support is implemented.
