### PR TITLE
chore: add clang format support

### DIFF
--- a/.circleci/clang_format.sh
+++ b/.circleci/clang_format.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -ex
+
+grep -nr '\s$' src test examples .gitignore .gitmodules 2>&1 > /dev/null
+if $?; then
+    echo Trailing whitespace found, aborting
+    exit 1
+fi
+
+# Default clang-format points to default 5.0 version one
+CLANG_FORMAT=clang-format-5.0
+$CLANG_FORMAT --version
+
+#TODO: Create equivlient for CircleCI
+#if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
+#    # Get list of every file modified in this pull request
+#    files_to_lint="$(git diff --name-only --diff-filter=ACMRTUXB $TRAVIS_COMMIT_RANGE | grep '^src/[^.]*[.]\(cpp\|h\)$' || true)"
+#else
+    # Check everything for branch pushes
+    files_to_lint="$(find . -not \( -path ./_3rdParty -prune \) -not \( -path ./CMakeFiles -prune \) -not \( -path ./src/lib -prune \) -not \( -path ./test/lib -prune \) -not \( -path ./examples/cmake_example/lib -prune \) -not \( -path ./examples/cmake_example/CMakeFiles -prune \) -not \( -path ./examples/platformio_example -prune \) -name \*.h -o -name \*.cpp)"
+#fi
+
+# Turn off tracing for this because it's too verbose
+set +x
+
+for f in $files_to_lint; do
+    d=$(diff -u "$f" <($CLANG_FORMAT "$f") || true)
+    if ! [ -z "$d" ]; then
+        echo "!!! $f not compliant to coding style, here is the fix:"
+        echo "$d"
+        fail=1
+    fi
+done
+
+set -x
+
+if [ "$fail" = 1 ]; then
+    # Don't fail the build yet
+    #exit 1
+    exit 0
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             sudo apt-add-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
             sudo apt-add-repository -y ppa:george-edison55/cmake-3.x
             sudo apt-get update
-            sudo apt-get -y install clang-5.0 clang-tidy-5.0 lcov cmake
+            sudo apt-get -y install clang-5.0 clang-format-5.0 clang-tidy-5.0 lcov cmake
       - run:
           name: Make scripts executable 
           command: sudo chmod -R +x ./.circleci/*.sh
@@ -61,6 +61,10 @@ jobs:
       - run:
           name: Clang Tidy
           command: ./.circleci/clang_tidy.sh
+      - run:
+          name: Clang Format
+          command: ./.circleci/clang_format.sh
+          
   build-macos-9-2:
     macos:
       xcode: "9.2.0"

--- a/.clang_format
+++ b/.clang_format
@@ -1,0 +1,4 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+Language:        Cpp
+BasedOnStyle:  Google


### PR DESCRIPTION
## Proposed changes
Added support for running clang format in CI.  clang format warnings will not error the build (yet?)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes

## Further comments
N/A
