### PR TITLE
fix: remove "two" references

### DIFF
--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -25,9 +25,8 @@ please see the [Cpp Crypto](https://github.com/ArkEcosystem/cpp-crypto) reposito
 ### Connection
 
 Before making a request, you should create a `Connection`.  
-A `Connection` expects a `host`, which is an url on which the API can be reached,  
-and a network `version`, which specifies whether we are using v1 or v2.  
-An example `Connection` that connects to a v2 API of a node, would be created as follows:
+A `Connection` expects a `host`, which is an url on which the API can be reached.  
+An example `Connection`, that interfaces with the API of an Ark Node, would be created as follows:
 
 ```cpp
 // Create a connection

--- a/examples/platformio_example/src/main.ino
+++ b/examples/platformio_example/src/main.ino
@@ -11,7 +11,7 @@ void setup() {
 
 void loop() {
   // Create a connection
-  Ark::Client::Connection<Ark::Client::API::Two> connection("167.114.29.54", 4003);
+  Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.54", 4003);
   
   // Check the API Version
   const auto apiVersion = connection.api.version();

--- a/test/api/blocks.cpp
+++ b/test/api/blocks.cpp
@@ -8,7 +8,7 @@
 using testing::Return;
 using testing::_;
 
-/* test_two_blocks_block
+/* test_blocks_block
  * https://dexplorer.ark.io:8443/api/v2/blocks/13114381566690093367
  * Expected Response:
     {

--- a/test/api/delegates.cpp
+++ b/test/api/delegates.cpp
@@ -8,7 +8,7 @@
 using testing::Return;
 using testing::_;
 
-/* test_two_delegates_delegate
+/* test_delegates_delegate
  * https://dexplorer.ark.io:8443/api/v2/delegates/boldninja
  * Expected Response:
     {

--- a/test/api/node.cpp
+++ b/test/api/node.cpp
@@ -9,7 +9,7 @@
 
 using testing::Return;
 
-/* test_two_node_configuration
+/* test_node_configuration
  * https://dexplorer.ark.io:8443/api/v2/node/configuration
  * Expected Response:
     {
@@ -103,7 +103,7 @@ using testing::Return;
     }
     }
 */
-TEST(api, test_two_node_configuration) { // NOLINT
+TEST(api, test_node_configuration) { // NOLINT
     Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();
@@ -201,7 +201,7 @@ TEST(api, test_two_node_configuration) { // NOLINT
         }
     }
  */
-TEST(api, test_two_node_status) { // NOLINT
+TEST(api, test_node_status) { // NOLINT
     Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();
@@ -248,7 +248,7 @@ TEST(api, test_two_node_status) { // NOLINT
     }
     }
  */
-TEST(api, test_two_node_syncing) { // NOLINT
+TEST(api, test_node_syncing) { // NOLINT
      Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();

--- a/test/api/peers.cpp
+++ b/test/api/peers.cpp
@@ -10,7 +10,7 @@
 using testing::Return;
 using testing::_;
 
-/* test_two_peers_peer
+/* test_peers_peer
  * https://dexplorer.ark.io:8443/api/v2/peers/167.114.29.54
  * Expected Response:
     {
@@ -24,7 +24,7 @@ using testing::_;
     }
     }
  */
-TEST(api, test_two_peer) { // NOLINT
+TEST(api, test_peer) { // NOLINT
      Ark::Client::Connection<MockApi> connection("167.114.29.54", 4003);
 
     auto apiVersion = connection.api.version();
@@ -97,7 +97,7 @@ TEST(api, test_two_peer) { // NOLINT
     ]
     }
  */
-TEST(api, test_two_peers) { // NOLINT
+TEST(api, test_peers) { // NOLINT
      Ark::Client::Connection<MockApi> connection("167.114.29.55", 4003);
 
     auto apiVersion = connection.api.version();

--- a/test/api/transactions.cpp
+++ b/test/api/transactions.cpp
@@ -10,7 +10,7 @@
 using testing::Return;
 using testing::_;
 
-/* test_two_transactions_transaction
+/* test_transactions_transaction
  * https://dexplorer.ark.io:8443/api/v2/transactions/b324cea5c5a6c15e6ced3ec9c3135a8022eeadb8169f7ba66c80ebc82b0ac850
  * Expected Response:
     {

--- a/test/api/votes.cpp
+++ b/test/api/votes.cpp
@@ -9,7 +9,7 @@
 using testing::Return;
 using testing::_;
 
-/* test_two_vote
+/* test_vote
  * https://dexplorer.ark.io:8443/api/v2/votes/d202acbfa947acac53ada2ac8a0eb662c9f75421ede3b10a42759352968b4ed2
  * Expected Response:
     {

--- a/test/api/wallets.cpp
+++ b/test/api/wallets.cpp
@@ -9,7 +9,7 @@
 using testing::Return;
 using testing::_;
 
-/* test_two_vote_identifier
+/* test_vote_identifier
  * https://dexplorer.ark.io:8443/api/v2/wallets/DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu
  * Expected Response:
     {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This PR removes references to "two" pertaining to the API version.

There's no reason to reference the distinction of "two" for API naming anymore.

These "two" references were mostly in test method names, as well as a reference in 'docs/cpp.md'.
They snuck through during the V1 drop.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)