### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,25 +6,25 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Ark KEYWORD1
-Client  KEYWORD1
-API KEYWORD1
+Ark	  KEYWORD1
+Client	KEYWORD1
+API	KEYWORD1
 
-Api KEYWORD1
+Api	KEYWORD1
 
-Blocks  KEYWORD1
-Delegates   KEYWORD1
-Node    KEYWORD1
-Peers   KEYWORD1
-Transactions    KEYWORD1
-Votes   KEYWORD1
-Wallets KEYWORD1
+Blocks	KEYWORD1
+Delegates	KEYWORD1
+Node	KEYWORD1
+Peers	KEYWORD1
+Transactions	KEYWORD1
+Votes	KEYWORD1
+Wallets	KEYWORD1
 
-Paths   KEYWORD1
+Paths	KEYWORD1
 
-Connection  KEYWORD1
+Connection	KEYWORD1
 
-Host    KEYWORD1
+Host	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
