### PR TITLE
fix(manifest): Correct Supported Platforms

### DIFF
--- a/library.json
+++ b/library.json
@@ -16,7 +16,10 @@
     }
   ],
   "frameworks": "arduino",
-  "platforms": "*",
+  "platforms": [
+    "espressif8266",
+    "espressif32"
+  ],
   "export": {
     "include": [
       "src/*",


### PR DESCRIPTION
As reported by @yhyuan in https://github.com/ArkEcosystem/cpp-crypto/issues/104,
the current library manifest uses a wildcard `*` for the `platforms` value signifying that it supports all platforms.

This is incorrect as the Cpp SDK's only officially support the espressif8266 & espressif32 platforms.  This PR corrects that discrepancy.

## What kind of change does this PR introduce?

- [x] Other, please describe:

Affects external package manager library manifest

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [n/a] New/updated tests are included
