### PR TITLE
fix: always send application/json as content-type

### DIFF
--- a/src/http/iot/http.cpp
+++ b/src/http/iot/http.cpp
@@ -85,9 +85,7 @@ class PlatformHTTP : public AbstractHTTP {
       httpClient.setReuse(true);
       httpClient.setTimeout(3000);
       httpClient.begin(toHttpStr(request).c_str());
-      (body[0] == '{') // set the header content-type
-        ? httpClient.addHeader("Content-Type", "application/json")
-        : httpClient.addHeader("Content-Type", "application/x-www-form-urlencoded");
+      httpClient.addHeader("Content-Type", "application/json")
       httpClient.POST(body);
       return httpClient.getString().c_str();
     }

--- a/src/http/iot/http.cpp
+++ b/src/http/iot/http.cpp
@@ -85,7 +85,7 @@ class PlatformHTTP : public AbstractHTTP {
       httpClient.setReuse(true);
       httpClient.setTimeout(3000);
       httpClient.begin(toHttpStr(request).c_str());
-      httpClient.addHeader("Content-Type", "application/json")
+      httpClient.addHeader("Content-Type", "application/json");
       httpClient.POST(body);
       return httpClient.getString().c_str();
     }

--- a/src/http/os/http.cpp
+++ b/src/http/os/http.cpp
@@ -56,7 +56,7 @@ class PlatformHTTP : public AbstractHTTP {
       return readBuffer;
     }
   /**/
-  
+
   std::string post(const char *const request, const char *body) override {
     // https://curl.haxx.se/libcurl/c/http-post.html
     CURL *curl;
@@ -71,11 +71,9 @@ class PlatformHTTP : public AbstractHTTP {
 
       /* set the header content-type */
       curl_slist *header_list = nullptr;
-      header_list = (body[0] == '{')
-        ? curl_slist_append(header_list, "Content-Type: application/json")
-        : curl_slist_append(header_list, "Content-Type: application/x-www-form-urlencoded");
+      header_list = url_slist_append(header_list, "Content-Type: application/json");
       curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
-      
+
       /* skip https verification */
       curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // Do NOT verify peer
       curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);  // Do NOT verify host

--- a/src/http/os/http.cpp
+++ b/src/http/os/http.cpp
@@ -71,7 +71,7 @@ class PlatformHTTP : public AbstractHTTP {
 
       /* set the header content-type */
       curl_slist *header_list = nullptr;
-      header_list = url_slist_append(header_list, "Content-Type: application/json");
+      header_list = curl_slist_append(header_list, "Content-Type: application/json");
       curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
 
       /* skip https verification */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Always send the `Content-Type: application/json` header for all HTTP verbs instead of performing a traditional form post for `POST` requests.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
