### PR TITLE
fix: refactor legacy

### DIFF
--- a/src/include/cpp-client/api/abstract.h
+++ b/src/include/cpp-client/api/abstract.h
@@ -24,8 +24,8 @@ protected:
   Host host_;
   std::unique_ptr<IHTTP> http_;
 
-  Abstract(IHTTP* http) : http_(http) {}
-  explicit Abstract() : http_(makeHTTP()) {}
+  Abstract() : http_(makeHTTP()) {}
+  explicit Abstract(IHTTP* http) : http_(http) {}
 
 public:
   void setHost(const char* const newHost, int newPort) { this->host_.set(newHost, newPort); };

--- a/src/include/cpp-client/http/http.h
+++ b/src/include/cpp-client/http/http.h
@@ -37,12 +37,10 @@ public:
  **/
 class AbstractHTTP : public IHTTP {
 protected:
+  AbstractHTTP() = default;
   AbstractHTTP(AbstractHTTP&&) = delete;
   AbstractHTTP& operator=(AbstractHTTP&&) = delete;
-
-  AbstractHTTP& operator=(const AbstractHTTP& other) noexcept {
-    return *this;
-  };
+  AbstractHTTP& operator=(const AbstractHTTP& other) = default;
 
 public:
   virtual ~AbstractHTTP(){};

--- a/test/mocks/mock_api.h
+++ b/test/mocks/mock_api.h
@@ -112,7 +112,7 @@ public:
   MockWallets wallets;
 
   MockApi()
-      : Abstract(new MockHTTP(), 2),
+      : Abstract(new MockHTTP()),
         blocks(host_, *http_),
         delegates(host_, *http_),
         node(host_, *http_),

--- a/test/mocks/mock_http.h
+++ b/test/mocks/mock_http.h
@@ -7,8 +7,6 @@
 
 class MockHTTP : public Ark::Client::IHTTP {
 public:
-  MockHTTP() = default;
-
   MOCK_METHOD1(get, std::string(const char* const));
   MOCK_METHOD2(post, std::string(const char* const, const char* const));
 };


### PR DESCRIPTION
Fixes remaining changes from `refactor/legacy` in #100 .

Specifically,

- [abstract.h]
  - `explicit` keyword moved to single argument constructor.
  > per: https://google.github.io/styleguide/cppguide.html#Implicit_Conversions
- [http.h]
  - added default constructor;
  - changed copy assignment operator to default.
- [test/mock_api.h]
  - removed legacy version-value from constructor.
- [test/mock_http.h]
  - removed default `MockHTTP()` constructor (now unneeded).
- [test/http.h]
  - fixes to make tests pass with current devnet core.
  - future PR should be done to use some other source.

## What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

 ~- [ ] It's submitted to the `develop` branch, _not_ the `master` branch~ n/a
- [x] All tests are passing

~- [n/a ] New/updated tests are included~ n/a
