### PR TITLE
fix: platformio tests src_filter

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -19,7 +19,7 @@ lib_deps = googletest@1.8.1
 # ignore the 'test' lib.  This isn't real but the build system somehow thinks that the test directory is also a library and does some double compiling of files
 lib_ignore = test
 build_flags = -I../test -I../src -I../src/include/cpp-client -DUNIT_TEST
-src_filter = +<../src> +<../test/iot> -<../src/http/os> -<../test/http> #ignore live HTTP tests on IoT
+src_filter = +<../src> +<../test> +<../test/iot> -<../src/http/os> -<../test/http> #ignore live HTTP tests on IoT
 upload_speed = 921600
 
 # esp8266 unit tests disabled until GTest/GMock support is worked out


### PR DESCRIPTION

## Summary

Current PlatformIO Test config causing skipped directory and crashing unit tests.

This PR resolves that error.

## Checklist

- [x] Ready to be merged
