### PR TITLE
fix: cmake warnings

### DIFF
--- a/cmake/extern/CURL.txt.in
+++ b/cmake/extern/CURL.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+project(curl-download)
+
 include(ExternalProject)
 
 # ------------------------------------------------------------------------------

--- a/cmake/extern/GTest.txt.in
+++ b/cmake/extern/GTest.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+project(googletest-download)
+
 include(ExternalProject)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

This PR adds project-download calls to silence external package build warnings.

## Checklist

- [x] Ready to be merged
