### PR TITLE
ci: hide mocked api coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,9 @@
 ignore:
-  - "test"
-  - "extras"
-  - "src/lib"
+  - "cmake/"
+  - "docs/"
+  - "examples/"
+  - "extern/"
+  - "extras/"
+  - "test/"
+  - "src/api/**/*.cpp"                    # hide mocked api
+  - "src/include/cpp-client/api/**/*.h"   # hide mocked api


### PR DESCRIPTION
## Summary

Mocked API show 0% coverage even though they're all tested.

This PR hides mocked API and other unused folders from coverage reports.

The `Paths`, `Connection`, `Host`, and `HTTP` classes are reported correctly.

A subsequent PR should address refactoring for testability and accurate coverage reports.

## Checklist

- [x] Ready to be merged