### PR TITLE
ci: split coverage workflows

### DIFF
--- a/.github/workflows/codeclimate.yml
+++ b/.github/workflows/codeclimate.yml
@@ -1,0 +1,35 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+
+jobs:
+  codeclimate:
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set compiler to clang++
+        run: COMPILER=clang++
+      - name: Install Dependencies
+        run: brew install cmake lcov
+      - name: Make scripts executable
+        run: sudo chmod +x ./.github/workflows/test/clang_tidy.sh
+      - name: Setup Code Climate test-reporter
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+      - name: Build & Run Coverage Tests
+        run: |
+          ./cc-test-reporter before-build
+          cmake -DCMAKE_BUILD_TYPE=Coverage -DUNIT_TEST=ON .
+          cmake --build .
+          ./test/ark_cpp_client_tests
+          lcov --directory . --include "*/src/*" --include "*/test/*" --exclude "*/src/lib/*" --exclude "*/extern/*" --capture --output-file coverage.info --ignore-errors gcov
+          ./cc-test-reporter format-coverage --input-type lcov coverage.info
+          ./cc-test-reporter upload-coverage
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,33 +9,6 @@ on:
     types: [ready_for_review, synchronize, opened]
 
 jobs:
-  codeclimate:
-    runs-on: macOS-latest
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set compiler to clang++
-        run: COMPILER=clang++
-      - name: Install Dependencies
-        run: brew install cmake lcov
-      - name: Make scripts executable
-        run: sudo chmod +x ./.github/workflows/test/clang_tidy.sh
-      - name: Setup Code Climate test-reporter
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-      - name: Build & Run Coverage Tests
-        run: |
-          ./cc-test-reporter before-build
-          cmake -DCMAKE_BUILD_TYPE=Coverage -DUNIT_TEST=ON .
-          cmake --build .
-          ./test/ark_cpp_client_tests
-          lcov --directory . --include "*/src/*" --include "*/test/*" --exclude "*/src/lib/*" --exclude "*/extern/*" --capture --output-file coverage.info --ignore-errors gcov
-          ./cc-test-reporter format-coverage --input-type lcov coverage.info
-          ./cc-test-reporter upload-coverage
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-
   codecov:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION

## Summary

As in the C++ Crypto repo, CodeClimate Coverage attempts to use the CC_TEST_REPORTER_ID of the PR base for reporting on the upstream parent and fails.

This PR splits workflows so that CodeClimate Coverage onlys runs on Pushes to master/devleop.

CodeCov will continue to run on PR's and Pushes.

## Checklist

- [x] Ready to be merged
