### PR TITLE
Fix ESP32 Tests

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -16,10 +16,8 @@ libdeps_dir = ../extern/.piolibdeps
 
 [common]
 lib_deps = googletest@1.8.1
-# ignore the 'test' lib.  This isn't real but the build system somehow thinks that the test directory is also a library and does some double compiling of files
-lib_ignore = test
 build_flags = -I../test -I../src -I../src/include/cpp-client -DUNIT_TEST
-src_filter = +<../src> +<../test> +<../test/iot> -<../src/http/os> -<../test/http> #ignore live HTTP tests on IoT
+src_filter = +<../src> +<test> +<../test/iot> -<../src/lib> -<../test/lib> -<../src/http/os> -<../test/http> #ignore live HTTP tests on IoT
 upload_speed = 921600
 
 # esp8266 unit tests disabled until GTest/GMock support is worked out


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

ESP32 test builds were not passing and the tests themselves were not
being compiled into the firmware binary.  Added missing ignore filters
to ignore desktop libraries for building PIO and desktop targets in the
same source tree.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
