### PR TITLE
ci: add esp8266 arduino cli configs back

### DIFF
--- a/.github/workflows/test/install_arduino.sh
+++ b/.github/workflows/test/install_arduino.sh
@@ -14,8 +14,10 @@ sudo ln -s /usr/local/share/arduino-cli /usr/local/bin/arduino-cli
 
 printf "board_manager:
   additional_urls:
-    - https://dl.espressif.com/dl/package_esp32_index.json" >> .cli-config.yml
+    - https://dl.espressif.com/dl/package_esp32_index.json
+    - http://arduino.esp8266.com/stable/package_esp8266com_index.json" >> .cli-config.yml
 sudo mv .cli-config.yml /usr/local/share/
 
 arduino-cli core update-index
 arduino-cli core install esp32:esp32
+arduino-cli core install esp8266:esp8266

--- a/.github/workflows/test/script_arduino.sh
+++ b/.github/workflows/test/script_arduino.sh
@@ -6,3 +6,5 @@ mkdir -p ~/Arduino/libraries/cpp-client/
 mv ${GITHUB_WORKSPACE}/* ~/Arduino/libraries/cpp-client
 
 arduino-cli compile --output temp.bin -b esp32:esp32:esp32 ~/Arduino/libraries/cpp-client/examples/arduino/ESP32/ESP32.ino --debug
+
+arduino-cli compile --output temp.bin -b esp8266:esp8266:nodemcu ~/Arduino/libraries/cpp-client/examples/arduino/ESP8266/ESP8266.ino --debug


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
With the recent support for esp8266 added back in, it would be nice to have that in the Arduino CLI CI tests.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
