### PR TITLE
chore: update to use official googletest repo

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -15,7 +15,7 @@ build_dir = ../build/.pioenvs
 libdeps_dir = ../extern/.piolibdeps
 
 [common]
-lib_deps = https://github.com/ciband/googletest.git#pre_release
+lib_deps = https://github.com/google/googletest.git#master
 build_flags = -I../test -I../src -I../src/include/cpp-client -DUNIT_TEST
 src_filter = +<../src> +<../test/iot> -<../src/http/os> -<../test/http> #ignore live HTTP tests on IoT
 upload_speed = 921600


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Google has official merged my PR to add esp8266 support to googletest.
This switches the dependency to use the official repo instead of my
fork.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
