### PR TITLE
build: hide cmake warning

### DIFF
--- a/cmake/extern/CURL.txt.in
+++ b/cmake/extern/CURL.txt.in
@@ -12,6 +12,7 @@ include(ExternalProject)
 ExternalProject_Add(CURL
   GIT_REPOSITORY    https://github.com/curl/curl
   GIT_TAG           curl-7_66_0
+  GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/curl/src"
   BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/curl/build"
   CONFIGURE_COMMAND ""

--- a/cmake/extern/GTest.txt.in
+++ b/cmake/extern/GTest.txt.in
@@ -12,6 +12,7 @@ include(ExternalProject)
 ExternalProject_Add(GoogleTest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           v1.10.x
+  GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/src"
   BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION

## Summary

- ignores detached head warnings when cloning external libs via CMake.

## Checklist

- [x] Ready to be merged
