### PR TITLE
chore(docs): add c++11 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Test Actions](https://github.com/ArkEcosystem/cpp-client/workflows/Test/badge.svg)](https://github.com/ArkEcosystem/cpp-client/actions)
 [![Coverage Actions](https://github.com/ArkEcosystem/cpp-client/workflows/Coverage/badge.svg)](https://github.com/ArkEcosystem/cpp-client/actions)
+[![C++11](https://badgen.net/badge/c++/11/blue?labelColor=black)](https://isocpp.org/wiki/faq/cpp11)
 [![Latest Version](https://badgen.now.sh/github/release/ArkEcosystem/cpp-client?labelColor=black)](https://github.com/ArkEcosystem/cpp-client/releases)
 [![License: MIT](https://badgen.now.sh/badge/license/MIT/green?labelColor=black)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION

## Summary

- add [![C++11](https://badgen.net/badge/c++/11/blue?labelColor=black)](https://isocpp.org/wiki/faq/cpp11) to `README.md` badges.

## Checklist

- [x] Ready to be merged
