### PR TITLE
test(pio): fix esp8266 platform urls

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -66,7 +66,7 @@ src_filter = +<../test/host>
 src_filter = +<../test/http>
 
 [env:esp8266_api_blockchain_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -76,7 +76,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_blocks_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -86,7 +86,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_delegates_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -96,7 +96,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_node_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -106,7 +106,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_paths_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -116,7 +116,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_peers_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -126,7 +126,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_rounds_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -136,7 +136,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_transactions_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -146,7 +146,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_votes_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -156,7 +156,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_api_wallets_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -166,7 +166,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_connection_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -176,7 +176,7 @@ upload_speed = ${common.upload_speed}
 board_build.f_cpu = ${esp8266.board_build.f_cpu}
 
 [env:esp8266_host_tests]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 framework = arduino
 lib_deps = ${common.lib_deps}


### PR DESCRIPTION

## Summary

Looks like PlatformIO stopped using their staging branch for ESP8266 firmware, which started causing build errors.

Changing the test PIO config to pull from their master branch resolves this issue.

## Checklist

- [x] Ready to be merged
