### PR TITLE
feat: support https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+-   added support for https ([#195])
+
 ## [1.4.1] - 2020-03-06
 
 ### Added
@@ -90,3 +95,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#176]: https://github.com/ArkEcosystem/cpp-client/pull/176
 [#183]: https://github.com/ArkEcosystem/cpp-client/pull/183
 [1.4.1]: https://github.com/ArkEcosystem/cpp-client/compare/1.4.0...1.4.1
+[#195]: https://github.com/ArkEcosystem/cpp-client/pull/195
+[Unreleased]: https://github.com/ArkEcosystem/cpp-client/compare/1.4.1...develop

--- a/examples/arduino/ESP32/ESP32.ino
+++ b/examples/arduino/ESP32/ESP32.ino
@@ -51,10 +51,14 @@ const char* password = "yourWiFiPassword";
  *  Specifically, this is a Devnet Node IP
  *  You can find more peers here: https://github.com/ArkEcosystem/peers
  *  
- *  The Public API port for the ARK network is '4003'
+ * The API port for ARK Explorer: '8443'
+ * - https://dexplorer.ark.io:8443
+ *
+ * The Public API port for the ARK network via IP Address is '4003'
+ * - 167.114.29.55:4003
  */
-const char* peer = "167.114.29.55";
-int port = 4003;
+const char* peer = "https://dexplorer.ark.io";
+int port = 8443;
 /**/
 
 /****************************************/

--- a/examples/arduino/ESP8266/ESP8266.ino
+++ b/examples/arduino/ESP8266/ESP8266.ino
@@ -47,14 +47,18 @@ const char* password = "yourWiFiPassword";
 /****************************************/
 
 /** 
- *  This is the IP address of an ARK Node
- *  Specifically, this is a Devnet Node IP
- *  You can find more peers here: https://github.com/ArkEcosystem/peers
- *  
- *  The Public API port for the ARK network is '4003'
+ * This is the IP address of an ARK Node
+ * Specifically, this is a Devnet Node IP
+ * You can find more peers here: https://github.com/ArkEcosystem/peers
+ * 
+ * The API port for ARK Explorer: '8443'
+ * - https://dexplorer.ark.io:8443
+ *
+ * The Public API port for the ARK network via IP Address is '4003'
+ * - 167.114.29.55:4003
  */
-const char* peer = "167.114.29.55";
-int port = 4003;
+const char* peer = "https://dexplorer.ark.io";
+const int port = 8443;
 /**/
 
 /****************************************/

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -41,7 +41,8 @@ std::string Host::toString() {
   out.reserve(IP_MAX_STRING_LEN + PORT_MAX_STRING_LEN);
   out += (this->ip_);
   out += ":";
-  snprintf(&out[out.find(":") + 1U], PORT_MAX_STRING_LEN, "%d", this->port_);
+  snprintf(&out[out.find_last_of(":") + 1U], PORT_MAX_STRING_LEN, "%d",
+           this->port_);
   return out;
 }
 

--- a/src/http/os/http.cpp
+++ b/src/http/os/http.cpp
@@ -19,64 +19,48 @@
 
 namespace Ark {
 namespace Client {
-namespace {  // NOLINT
+namespace {
 
 class PlatformHTTP : public AbstractHTTP {
  public:
   PlatformHTTP() = default;
 
-  static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
-    // https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
+  //////////////////////////////////////////////////////////////////////////////
+  std::string get(const char *request) override { return this->send(request); }
+
+  //////////////////////////////////////////////////////////////////////////////
+  std::string post(const char *request, const char *body) override {
+    return this->send(request, body);
+  }
+
+ private:
+  //////////////////////////////////////////////////////////////////////////////
+  // - https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
+  static inline size_t WriteCallback(void *contents, size_t size, size_t nmemb,
+                                     void *userp) {
     ((std::string *)userp)->append((char *)contents, size * nmemb);
     return size * nmemb;
   }
-
-  /**/
-
-  std::string get(const char* request) override {
+  //////////////////////////////////////////////////////////////////////////////
+  // Combines GET and POST operations.
+  // - https://curl.haxx.se/libcurl/c/https.html
+  // - https://curl.haxx.se/libcurl/c/http-post.html
+  inline std::string send(const char *request, const char *body = nullptr) {
     CURL *curl;
-    CURLcode res;
-    std::string readBuffer;
-
-    curl = curl_easy_init();
-    if (curl != nullptr) {
-      curl_easy_setopt(curl, CURLOPT_URL, request);
-
-      curl_slist *header_list = nullptr;
-      header_list = curl_slist_append(header_list, "Content-Type: application/json");
-      curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
-
-      /* skip https verification */
-      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
-
-      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-      curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
-      curl_easy_perform(curl);
-      curl_slist_free_all(header_list);
-      curl_easy_cleanup(curl);
-    }
-    return readBuffer;
-  }
-
-  /**/
-
-  std::string post(const char* request, const char *body) override {
-    // https://curl.haxx.se/libcurl/c/http-post.html
-    CURL *curl;
-    CURLcode res;
-    std::string readBuffer;
-
     curl_global_init(CURL_GLOBAL_ALL);
+    std::string readBuffer;
+
     curl = curl_easy_init();
     if (curl != nullptr) {
       curl_easy_setopt(curl, CURLOPT_URL, request);
-      curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+      if (body) {
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+      }
 
       /* set the header content-type */
-      curl_slist *header_list = nullptr;
-      header_list = curl_slist_append(header_list, "Content-Type: application/json");
-      curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+      curl_slist *headers = nullptr;
+      headers = curl_slist_append(headers, "Content-Type: application/json");
+      curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
       /* skip https verification */
       curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // Do NOT verify peer
@@ -84,23 +68,27 @@ class PlatformHTTP : public AbstractHTTP {
 
       curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
-      res = curl_easy_perform(curl);
-      if (res != CURLE_OK) {
-        fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
-      };
-      /* always cleanup */
-      curl_easy_cleanup(curl);
-    };
-    curl_global_cleanup();
-    return readBuffer;
-  };
-};
 
+      const CURLcode result = curl_easy_perform(curl);
+      if (result != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                curl_easy_strerror(result));
+      }
+
+      /* always cleanup */
+      curl_slist_free_all(headers);
+      curl_easy_cleanup(curl);
+    }
+
+    curl_global_cleanup();
+
+    return readBuffer;
+  }
+};
 }  // namespace
 
-/**
- * HTTP Object Factory
- **/
+////////////////////////////////////////////////////////////////////////////////
+// HTTP Object Factory
 std::unique_ptr<IHTTP> makeHTTP() {
   return std::unique_ptr<IHTTP>(new PlatformHTTP());
 }
@@ -108,4 +96,4 @@ std::unique_ptr<IHTTP> makeHTTP() {
 }  // namespace Client
 }  // namespace Ark
 
-#endif
+#endif  // USE_IOT

--- a/test/http/http.cpp
+++ b/test/http/http.cpp
@@ -13,7 +13,7 @@ using namespace Ark::Client;
 constexpr const size_t HTTPS_MAX_ELEMENTS = 3U;
 }  // namespace
 
-TEST(api, test_http_get) { // NOLINT
+TEST(api, test_http_get) {  // NOLINT
   // Create the HTTP object
   const auto http = makeHTTP();
 
@@ -28,8 +28,23 @@ TEST(api, test_http_get) { // NOLINT
 
 /**/
 
+TEST(api, test_https_get) {  // NOLINT
+  // Create the HTTP object
+  const auto https = makeHTTP();
+
+  // Create a request
+  const auto request = "https://postman-echo.com/get?foo=bar";
+
+  // Get the response using HTTP
+  const auto response = https->get(request);
+
+  ASSERT_LT(response.find("bar"), response.length());
+}
+
+/**/
+
 // Tests POSTing of HTTP body.
-TEST(api, test_http_post_body) { // NOLINT
+TEST(api, test_http_post_body) {  // NOLINT
   // Create the HTTP object
   const auto http = makeHTTP();
 
@@ -45,8 +60,25 @@ TEST(api, test_http_post_body) { // NOLINT
 
 /**/
 
+// Tests POSTing of HTTP body.
+TEST(api, test_https_post_body) {  // NOLINT
+  // Create the HTTP object
+  const auto https = makeHTTP();
+
+  // Create a Request URL and 'Post' body.
+  const auto request = "https://postman-echo.com/post";
+  const auto body = "This should be sent back as part of response body.";
+
+  // Post the 'request' and 'body' for a response using HTTP
+  const auto response = https->post(request, body);
+
+  ASSERT_LT(response.find(body), response.length());
+}
+
+/**/
+
 // Tests invalid POSTing of HTTP body.
-TEST(api, test_http_invalid_post_body) { // NOLINT
+TEST(api, test_http_invalid_post_body) {  // NOLINT
   // Create the HTTP object
   const auto http = makeHTTP();
 
@@ -59,7 +91,7 @@ TEST(api, test_http_invalid_post_body) { // NOLINT
 
   // The malformed request will result in the following error being logged:
   // 'curl_easy_perform() failed: URL using bad/illegal format or missing URL'
-  
+
   // the response will be empty
   ASSERT_TRUE(response.empty());
 }
@@ -67,7 +99,7 @@ TEST(api, test_http_invalid_post_body) { // NOLINT
 /**/
 
 // Tests POSTing of JSON.
-TEST(api, test_http_post_json) { // NOLINT
+TEST(api, test_http_post_json) {  // NOLINT
   // Create the HTTP object
   const auto http = makeHTTP();
 
@@ -84,26 +116,19 @@ TEST(api, test_http_post_json) { // NOLINT
 /**/
 
 // This tests the use of "http://" in single-line HTTP requests.
-TEST(api, test_http_request_strings) { // NOLINT
+TEST(api, test_http_request_strings) {  // NOLINT
   std::array<std::string, HTTPS_MAX_ELEMENTS> requests = {
-    "postman-echo.com/get",         // No HTTP prefix
-    "http://postman-echo.com/get",  // HTTP
-    "https://postman-echo.com/get"  // HTTPS
+      "postman-echo.com/get",         // No HTTP prefix
+      "http://postman-echo.com/get",  // HTTP
+      "https://postman-echo.com/get"  // HTTPS
   };
 
   // Create the HTTP object
   const auto http = makeHTTP();
 
-  for (auto& i: requests) {
+  for (auto& i : requests) {
     // Get the response using HTTP
     const auto response = http->get(i.c_str());
-#ifdef USE_IOT 
-    // HTTPS is NOT supported on IoT and should fail to parse.
-    response.find("https://") < response.length())
-        ? ASSERT_TRUE(response.empth())
-        : ASSERT_LT(response.find("args"), response.length());
-#else // OS Builds
     ASSERT_LT(response.find("args"), response.length());
-#endif
   };
 }


### PR DESCRIPTION

## Summary

Add Https support for OS and IoT builds. 

- '**host.cpp**': add support for url prefixes (http(s)://)\<address>:\<port>.
- '**http.cpp**': refactor and add support for Https.
- '**test/http**': update tests to reflect changes.
- update arduino examples.
- update CHANGELOG.

This resolves #191 & #192 

## Checklist

- [x] Documentation 
- [x] Tests
- [x] Ready to be merged
