### PR TITLE
feat: support https [arduino]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+-   added support for https ([#196])
+
 ## [1.4.1] - 2020-03-06
 
 ### Added
@@ -77,3 +82,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [1.4.0]: https://github.com/ArkEcosystem/cpp-client/compare/1.3.0-arduino...1.4.0-arduino
 [#185]: https://github.com/ArkEcosystem/cpp-client/pull/185
 [1.4.1]: https://github.com/ArkEcosystem/cpp-client/compare/1.4.0-arduino...1.4.1-arduino
+[#196]: https://github.com/ArkEcosystem/cpp-client/pull/196
+[Unreleased]: https://github.com/ArkEcosystem/cpp-client/compare/1.4.1-arduino...arduino

--- a/examples/ESP32/ESP32.ino
+++ b/examples/ESP32/ESP32.ino
@@ -51,10 +51,14 @@ const char* password = "yourWiFiPassword";
  *  Specifically, this is a Devnet Node IP
  *  You can find more peers here: https://github.com/ArkEcosystem/peers
  *  
- *  The Public API port for the ARK network is '4003'
+ * The API port for ARK Explorer: '8443'
+ * - https://dexplorer.ark.io:8443
+ *
+ * The Public API port for the ARK network via IP Address is '4003'
+ * - 167.114.29.55:4003
  */
-const char* peer = "167.114.29.55";
-int port = 4003;
+const char* peer = "https://dexplorer.ark.io";
+int port = 8443;
 /**/
 
 /****************************************/

--- a/examples/ESP8266/ESP8266.ino
+++ b/examples/ESP8266/ESP8266.ino
@@ -47,14 +47,18 @@ const char* password = "yourWiFiPassword";
 /****************************************/
 
 /** 
- *  This is the IP address of an ARK Node
- *  Specifically, this is a Devnet Node IP
- *  You can find more peers here: https://github.com/ArkEcosystem/peers
- *  
- *  The Public API port for the ARK network is '4003'
+ * This is the IP address of an ARK Node
+ * Specifically, this is a Devnet Node IP
+ * You can find more peers here: https://github.com/ArkEcosystem/peers
+ * 
+ * The API port for ARK Explorer: '8443'
+ * - https://dexplorer.ark.io:8443
+ *
+ * The Public API port for the ARK network via IP Address is '4003'
+ * - 167.114.29.55:4003
  */
-const char* peer = "167.114.29.55";
-int port = 4003;
+const char* peer = "https://dexplorer.ark.io";
+const int port = 8443;
 /**/
 
 /****************************************/

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -41,7 +41,8 @@ std::string Host::toString() {
   out.reserve(IP_MAX_STRING_LEN + PORT_MAX_STRING_LEN);
   out += (this->ip_);
   out += ":";
-  snprintf(&out[out.find(":") + 1U], PORT_MAX_STRING_LEN, "%d", this->port_);
+  snprintf(&out[out.find_last_of(":") + 1U], PORT_MAX_STRING_LEN, "%d",
+           this->port_);
   return out;
 }
 


### PR DESCRIPTION

## Summary

Add Https support for Arduino. 

- '**host.cpp**': add support for url prefixes (http(s)://)\<address>:\<port>.
- '**http.cpp**': refactor and add support for Https.
- update arduino examples.
- update CHANGELOG.

## Checklist

- [x] Documentation
- [x] Ready to be merged
